### PR TITLE
Add CMSA metaheuristic with MVC example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ docs/apidocs
 log.txt
 .benchmark
 **/docs
+!/docs/
 /example-graphs/instances/
 site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Developing
+- (New) CMSA (Construct, Merge, Solve & Adapt) algorithm. See CMSA, CMSAConstructive, CMSASolver and CMSABuilder in the algorithms.cmsa package, and the new metaheuristics/cmsa.md doc page.
 - (Breaking) Remove the obsolete `irace.shell` property; R execution is selected through `RLangRunner` implementations.
 - (Breaking) Replace Spring-annotated Mork event listener methods with direct `MorkEventListener` implementations.
 - (Fix) Progress bar in console was drawn incorrectly while printing logs to console.

--- a/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSA.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSA.java
@@ -8,14 +8,12 @@ import es.urjc.etsii.grafo.io.Instance;
 import es.urjc.etsii.grafo.metrics.Metrics;
 import es.urjc.etsii.grafo.solution.Objective;
 import es.urjc.etsii.grafo.solution.Solution;
-import es.urjc.etsii.grafo.util.Context;
 import es.urjc.etsii.grafo.util.StringUtil;
 import es.urjc.etsii.grafo.util.TimeControl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -122,15 +120,16 @@ public class CMSA<S extends Solution<S, I>, I extends Instance, C> extends Algor
      * @param solverTimeLimitInMillis maximum time budget, in milliseconds, given to the solver at each iteration
      * @param maxIterations           maximum number of iterations, use a value smaller or equal to zero to only rely on the global time limit
      */
+    @AutoconfigConstructor
     public CMSA(
-            String name,
-            Objective<?, S, I> objective,
+            @ProvidedParam String name,
+            @ProvidedParam Objective<?, S, I> objective,
             CMSAConstructive<S, I, C> constructive,
             CMSASolver<S, I, C> solver,
-            int solutionsPerIteration,
-            int ageMax,
-            long solverTimeLimitInMillis,
-            int maxIterations
+            @IntegerParam(min = 1, max = 1_000) int solutionsPerIteration,
+            @IntegerParam(min = 0, max = 100) int ageMax,
+            @IntegerParam(min = 1, max = 60_000) long solverTimeLimitInMillis,
+            @IntegerParam(min = 0, max = 1_000_000) int maxIterations
     ) {
         super(name);
         if (solutionsPerIteration < 1) {
@@ -151,24 +150,10 @@ public class CMSA<S extends Solution<S, I>, I extends Instance, C> extends Algor
         this.maxIterations = maxIterations;
     }
 
-    @AutoconfigConstructor
-    public CMSA(
-            @ProvidedParam String name,
-            CMSAConstructive<S, I, C> constructive,
-            CMSASolver<S, I, C> solver,
-            @IntegerParam(min = 1, max = 1_000) int solutionsPerIteration,
-            @IntegerParam(min = 0, max = 100) int ageMax,
-            @IntegerParam(min = 1, max = 60_000) long solverTimeLimitInMillis,
-            @IntegerParam(min = 0, max = 1_000_000) int maxIterations
-    ) {
-        this(name, Context.getMainObjective(), constructive, solver, solutionsPerIteration, ageMax, solverTimeLimitInMillis, maxIterations);
-    }
-
     /** {@inheritDoc} */
     @Override
     public S algorithm(I instance) {
-        Map<C, Integer> age = new HashMap<>();
-        Set<C> subInstance = new HashSet<>();
+        Map<C, Integer> componentAges = new HashMap<>();
         S best = null;
 
         int iteration = 0;
@@ -178,9 +163,7 @@ public class CMSA<S extends Solution<S, I>, I extends Instance, C> extends Algor
             for (int i = 0; i < solutionsPerIteration && !TimeControl.isTimeUp(); i++) {
                 S candidate = this.constructive.construct(this.newSolution(instance));
                 for (var component : this.constructive.usedComponents(candidate)) {
-                    if (subInstance.add(component)) {
-                        age.put(component, 0);
-                    }
+                    componentAges.putIfAbsent(component, 0);
                 }
             }
 
@@ -196,28 +179,31 @@ public class CMSA<S extends Solution<S, I>, I extends Instance, C> extends Algor
             if (timeBudget <= 0) {
                 break;
             }
-            S solved = this.solver.solve(instance, Set.copyOf(subInstance), timeBudget);
+            S solved = this.solver.solve(instance, Set.copyOf(componentAges.keySet()), timeBudget);
 
             if (solved != null) {
                 if (best == null || objective.isBetter(solved, best)) {
-                    log.debug("Iteration {}: improved best solution: {} --> {}", iteration,
-                            best == null ? "none" : objective.evalSol(best), objective.evalSol(solved));
+                    if (log.isDebugEnabled()) {
+                        log.debug("Iteration {}: improved best solution: {} --> {}", iteration,
+                                best == null ? "none" : objective.evalSol(best), objective.evalSol(solved));
+                    }
                     best = solved;
                     Metrics.addCurrentObjectives(best);
                 }
 
                 // Adapt: components used by the solver stay young, the rest age and eventually drop out
                 Set<C> usedBySolver = this.constructive.usedComponents(solved);
-                Iterator<C> it = subInstance.iterator();
+                Iterator<Map.Entry<C, Integer>> it = componentAges.entrySet().iterator();
                 while (it.hasNext()) {
-                    C component = it.next();
-                    if (usedBySolver.contains(component)) {
-                        age.put(component, 0);
+                    Map.Entry<C, Integer> entry = it.next();
+                    if (usedBySolver.contains(entry.getKey())) {
+                        entry.setValue(0);
                     } else {
-                        int componentAge = age.merge(component, 1, Integer::sum);
+                        int componentAge = entry.getValue() + 1;
                         if (componentAge > ageMax) {
                             it.remove();
-                            age.remove(component);
+                        } else {
+                            entry.setValue(componentAge);
                         }
                     }
                 }

--- a/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSA.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSA.java
@@ -66,8 +66,9 @@ import java.util.Set;
  *
  * @param <S> Solution class
  * @param <I> Instance class
+ * @param <C> Solution component class
  */
-public class CMSA<S extends Solution<S, I>, I extends Instance> extends Algorithm<S, I> {
+public class CMSA<S extends Solution<S, I>, I extends Instance, C> extends Algorithm<S, I> {
 
     private static final Logger log = LoggerFactory.getLogger(CMSA.class);
 
@@ -76,12 +77,12 @@ public class CMSA<S extends Solution<S, I>, I extends Instance> extends Algorith
     /**
      * Probabilistic constructive procedure used to sample solution components at every iteration.
      */
-    private final CMSAConstructive<S, I> constructive;
+    private final CMSAConstructive<S, I, C> constructive;
 
     /**
      * Exact (or near-exact) method used to solve the restricted sub-instance at every iteration.
      */
-    private final CMSASolver<S, I> solver;
+    private final CMSASolver<S, I, C> solver;
 
     /**
      * Number of solutions probabilistically constructed at each iteration, before merging their
@@ -124,8 +125,8 @@ public class CMSA<S extends Solution<S, I>, I extends Instance> extends Algorith
     public CMSA(
             String name,
             Objective<?, S, I> objective,
-            CMSAConstructive<S, I> constructive,
-            CMSASolver<S, I> solver,
+            CMSAConstructive<S, I, C> constructive,
+            CMSASolver<S, I, C> solver,
             int solutionsPerIteration,
             int ageMax,
             long solverTimeLimitInMillis,
@@ -153,8 +154,8 @@ public class CMSA<S extends Solution<S, I>, I extends Instance> extends Algorith
     @AutoconfigConstructor
     public CMSA(
             @ProvidedParam String name,
-            CMSAConstructive<S, I> constructive,
-            CMSASolver<S, I> solver,
+            CMSAConstructive<S, I, C> constructive,
+            CMSASolver<S, I, C> solver,
             @IntegerParam(min = 1, max = 1_000) int solutionsPerIteration,
             @IntegerParam(min = 0, max = 100) int ageMax,
             @IntegerParam(min = 1, max = 60_000) long solverTimeLimitInMillis,
@@ -166,8 +167,8 @@ public class CMSA<S extends Solution<S, I>, I extends Instance> extends Algorith
     /** {@inheritDoc} */
     @Override
     public S algorithm(I instance) {
-        Map<Object, Integer> age = new HashMap<>();
-        Set<Object> subInstance = new HashSet<>();
+        Map<C, Integer> age = new HashMap<>();
+        Set<C> subInstance = new HashSet<>();
         S best = null;
 
         int iteration = 0;
@@ -206,10 +207,10 @@ public class CMSA<S extends Solution<S, I>, I extends Instance> extends Algorith
                 }
 
                 // Adapt: components used by the solver stay young, the rest age and eventually drop out
-                Set<Object> usedBySolver = this.constructive.usedComponents(solved);
-                Iterator<Object> it = subInstance.iterator();
+                Set<C> usedBySolver = this.constructive.usedComponents(solved);
+                Iterator<C> it = subInstance.iterator();
                 while (it.hasNext()) {
-                    Object component = it.next();
+                    C component = it.next();
                     if (usedBySolver.contains(component)) {
                         age.put(component, 0);
                     } else {

--- a/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSA.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSA.java
@@ -1,0 +1,248 @@
+package es.urjc.etsii.grafo.algorithms.cmsa;
+
+import es.urjc.etsii.grafo.algorithms.Algorithm;
+import es.urjc.etsii.grafo.annotations.AutoconfigConstructor;
+import es.urjc.etsii.grafo.annotations.IntegerParam;
+import es.urjc.etsii.grafo.annotations.ProvidedParam;
+import es.urjc.etsii.grafo.io.Instance;
+import es.urjc.etsii.grafo.metrics.Metrics;
+import es.urjc.etsii.grafo.solution.Objective;
+import es.urjc.etsii.grafo.solution.Solution;
+import es.urjc.etsii.grafo.util.Context;
+import es.urjc.etsii.grafo.util.StringUtil;
+import es.urjc.etsii.grafo.util.TimeControl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * CMSA (Construct, Merge, Solve and Adapt) is a hybrid metaheuristic that combines a probabilistic
+ * constructive heuristic with an exact method. Instead of applying the exact method to the whole problem
+ * instance, which is usually intractable, CMSA repeatedly restricts the search to a small, promising subset
+ * of solution components (edges, assignments, items, etc.), and solves that much smaller sub-instance to
+ * optimality (or as close to optimality as possible) at every iteration.
+ * <p>
+ * Algorithmic outline:
+ * <pre>
+ * Csub = {} // sub-instance: solution components with a chance of being part of a good solution
+ * Sbest = null
+ * repeat until stopping criterion is met:
+ *     // Construct &amp; Merge
+ *     for na times:
+ *         S' = ProbabilisticConstruct(instance) // {@link CMSAConstructive}
+ *         Csub = Csub U usedComponents(S')       // merge new components into the sub-instance, age = 0
+ *     // Solve
+ *     S* = Solve(instance restricted to Csub)    // {@link CMSASolver}
+ *     if S* is better than Sbest: Sbest = S*
+ *     // Adapt
+ *     for each component c in Csub:
+ *         if c in S*: age(c) = 0
+ *         else: age(c) = age(c) + 1
+ *               if age(c) &gt; ageMax: Csub = Csub \ {c}
+ * return Sbest
+ * </pre>
+ * Components that keep being selected by the exact method stay in {@code Csub} indefinitely (their age is
+ * reset to 0), while components that are no longer useful eventually age out and are dropped, keeping the
+ * sub-instance small across iterations. This is what makes CMSA different from just repeatedly solving a
+ * new random restricted sub-instance from scratch: the sub-instance progressively adapts towards the
+ * components that matter.
+ * <p>
+ * For further information about CMSA see:
+ * Blum, C., Pinacho, P., López-Ibáñez, M., &amp; Lozano, J. A. (2016). Construct, Merge, Solve and Adapt:
+ * A new algorithm for combinatorial optimization. Computers &amp; Operations Research, 68, 75-88.
+ * <a href="https://doi.org/10.1016/j.cor.2015.10.014">...</a>
+ * <p>
+ * For an in-depth treatment of CMSA, including guidance on modelling the sub-instance solved at every
+ * iteration for different combinatorial optimization problems, see:
+ * Blum, C. (2024). Construct, Merge, Solve &amp; Adapt: A Hybrid Metaheuristic for Combinatorial Optimization.
+ * Computational Intelligence Methods and Applications. Springer.
+ * <a href="https://doi.org/10.1007/978-3-031-60103-3">...</a>
+ *
+ * @param <S> Solution class
+ * @param <I> Instance class
+ */
+public class CMSA<S extends Solution<S, I>, I extends Instance> extends Algorithm<S, I> {
+
+    private static final Logger log = LoggerFactory.getLogger(CMSA.class);
+
+    private final Objective<?, S, I> objective;
+
+    /**
+     * Probabilistic constructive procedure used to sample solution components at every iteration.
+     */
+    private final CMSAConstructive<S, I> constructive;
+
+    /**
+     * Exact (or near-exact) method used to solve the restricted sub-instance at every iteration.
+     */
+    private final CMSASolver<S, I> solver;
+
+    /**
+     * Number of solutions probabilistically constructed at each iteration, before merging their
+     * components into the sub-instance and calling the solver. Commonly denoted as {@code na} in the literature.
+     */
+    private final int solutionsPerIteration;
+
+    /**
+     * Maximum age a solution component can reach, while not being used by the solver, before being
+     * removed from the sub-instance.
+     */
+    private final int ageMax;
+
+    /**
+     * Maximum time budget, in milliseconds, given to the solver at each iteration to solve the
+     * restricted sub-instance. If less time than this remains in the current execution, the remaining
+     * time is used instead.
+     */
+    private final long solverTimeLimitInMillis;
+
+    /**
+     * Maximum number of iterations to execute. Use a value smaller or equal to zero to disable this
+     * limit and rely exclusively on the global time limit.
+     */
+    private final int maxIterations;
+
+    /**
+     * Full CMSA constructor.
+     *
+     * @param name                    Algorithm name, uniquely identifies the current algorithm.
+     *                                Tip: If you dont care about the name, generate a random one using {@link StringUtil#randomAlgorithmName()}
+     * @param objective               objective function to optimize
+     * @param constructive            probabilistic constructive procedure used to sample solution components
+     * @param solver                  exact (or near-exact) method used to solve the restricted sub-instance
+     * @param solutionsPerIteration   number of solutions constructed at each iteration before calling the solver, usually denoted {@code na}
+     * @param ageMax                  maximum age a solution component can reach before being removed from the sub-instance
+     * @param solverTimeLimitInMillis maximum time budget, in milliseconds, given to the solver at each iteration
+     * @param maxIterations           maximum number of iterations, use a value smaller or equal to zero to only rely on the global time limit
+     */
+    public CMSA(
+            String name,
+            Objective<?, S, I> objective,
+            CMSAConstructive<S, I> constructive,
+            CMSASolver<S, I> solver,
+            int solutionsPerIteration,
+            int ageMax,
+            long solverTimeLimitInMillis,
+            int maxIterations
+    ) {
+        super(name);
+        if (solutionsPerIteration < 1) {
+            throw new IllegalArgumentException("solutionsPerIteration must be greater than 0");
+        }
+        if (ageMax < 0) {
+            throw new IllegalArgumentException("ageMax must be greater or equal to 0");
+        }
+        if (solverTimeLimitInMillis < 1) {
+            throw new IllegalArgumentException("solverTimeLimitInMillis must be greater than 0");
+        }
+        this.objective = Objects.requireNonNull(objective);
+        this.constructive = Objects.requireNonNull(constructive);
+        this.solver = Objects.requireNonNull(solver);
+        this.solutionsPerIteration = solutionsPerIteration;
+        this.ageMax = ageMax;
+        this.solverTimeLimitInMillis = solverTimeLimitInMillis;
+        this.maxIterations = maxIterations;
+    }
+
+    @AutoconfigConstructor
+    public CMSA(
+            @ProvidedParam String name,
+            CMSAConstructive<S, I> constructive,
+            CMSASolver<S, I> solver,
+            @IntegerParam(min = 1, max = 1_000) int solutionsPerIteration,
+            @IntegerParam(min = 0, max = 100) int ageMax,
+            @IntegerParam(min = 1, max = 60_000) long solverTimeLimitInMillis,
+            @IntegerParam(min = 0, max = 1_000_000) int maxIterations
+    ) {
+        this(name, Context.getMainObjective(), constructive, solver, solutionsPerIteration, ageMax, solverTimeLimitInMillis, maxIterations);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public S algorithm(I instance) {
+        Map<Object, Integer> age = new HashMap<>();
+        Set<Object> subInstance = new HashSet<>();
+        S best = null;
+
+        int iteration = 0;
+        while (!TimeControl.isTimeUp() && (maxIterations <= 0 || iteration < maxIterations)) {
+
+            // Construct & Merge
+            for (int i = 0; i < solutionsPerIteration && !TimeControl.isTimeUp(); i++) {
+                S candidate = this.constructive.construct(this.newSolution(instance));
+                for (var component : this.constructive.usedComponents(candidate)) {
+                    if (subInstance.add(component)) {
+                        age.put(component, 0);
+                    }
+                }
+            }
+
+            if (TimeControl.isTimeUp()) {
+                break;
+            }
+
+            // Solve
+            long timeBudget = solverTimeLimitInMillis;
+            if (TimeControl.isEnabled()) {
+                timeBudget = Math.min(timeBudget, TimeControl.remaining() / 1_000_000);
+            }
+            if (timeBudget <= 0) {
+                break;
+            }
+            S solved = this.solver.solve(instance, Set.copyOf(subInstance), timeBudget);
+
+            if (solved != null) {
+                if (best == null || objective.isBetter(solved, best)) {
+                    log.debug("Iteration {}: improved best solution: {} --> {}", iteration,
+                            best == null ? "none" : objective.evalSol(best), objective.evalSol(solved));
+                    best = solved;
+                    Metrics.addCurrentObjectives(best);
+                }
+
+                // Adapt: components used by the solver stay young, the rest age and eventually drop out
+                Set<Object> usedBySolver = this.constructive.usedComponents(solved);
+                Iterator<Object> it = subInstance.iterator();
+                while (it.hasNext()) {
+                    Object component = it.next();
+                    if (usedBySolver.contains(component)) {
+                        age.put(component, 0);
+                    } else {
+                        int componentAge = age.merge(component, 1, Integer::sum);
+                        if (componentAge > ageMax) {
+                            it.remove();
+                            age.remove(component);
+                        }
+                    }
+                }
+            } else {
+                log.debug("Iteration {}: solver could not find a feasible solution to the restricted sub-instance", iteration);
+            }
+
+            iteration++;
+        }
+
+        if (best == null) {
+            throw new IllegalStateException("CMSA did not find any feasible solution. Review the CMSASolver implementation, " +
+                    "or increase solverTimeLimitInMillis / solutionsPerIteration so the sub-instance is easier to solve.");
+        }
+
+        return best;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return "CMSA{" +
+                "constructive=" + constructive +
+                ", solver=" + solver +
+                ", na=" + solutionsPerIteration +
+                ", ageMax=" + ageMax +
+                '}';
+    }
+}

--- a/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSABuilder.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSABuilder.java
@@ -1,0 +1,136 @@
+package es.urjc.etsii.grafo.algorithms.cmsa;
+
+import es.urjc.etsii.grafo.io.Instance;
+import es.urjc.etsii.grafo.solution.Objective;
+import es.urjc.etsii.grafo.solution.Solution;
+import es.urjc.etsii.grafo.util.Context;
+import es.urjc.etsii.grafo.util.StringUtil;
+
+/**
+ * CMSA algorithm builder based on the Java Builder Pattern.
+ *
+ * @param <S> type of the solution of the problem
+ * @param <I> type of the instance of the problem
+ */
+public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
+
+    private Objective<?, S, I> objective;
+    private CMSAConstructive<S, I> constructive;
+    private CMSASolver<S, I> solver;
+    private int solutionsPerIteration = 30;
+    private int ageMax = 5;
+    private long solverTimeLimitInMillis = 1_000;
+    private int maxIterations = 0;
+
+    /**
+     * Configures the probabilistic constructive procedure used to sample solution components.
+     * @param constructive probabilistic constructive procedure
+     * @return this builder instance for method chaining
+     */
+    public CMSABuilder<S, I> withConstructive(CMSAConstructive<S, I> constructive) {
+        this.constructive = constructive;
+        return this;
+    }
+
+    /**
+     * Configures the exact (or near-exact) method used to solve the restricted sub-instance.
+     * @param solver exact method implementation
+     * @return this builder instance for method chaining
+     */
+    public CMSABuilder<S, I> withSolver(CMSASolver<S, I> solver) {
+        this.solver = solver;
+        return this;
+    }
+
+    /**
+     * Configures how many solutions are probabilistically constructed at each iteration before
+     * merging their components into the sub-instance and calling the solver. Defaults to 30.
+     * @param solutionsPerIteration number of solutions constructed at each iteration, usually denoted {@code na}
+     * @return this builder instance for method chaining
+     */
+    public CMSABuilder<S, I> withSolutionsPerIteration(int solutionsPerIteration) {
+        this.solutionsPerIteration = solutionsPerIteration;
+        return this;
+    }
+
+    /**
+     * Configures the maximum age a solution component can reach, while not being used by the solver,
+     * before being removed from the sub-instance. Defaults to 5.
+     * @param ageMax maximum component age
+     * @return this builder instance for method chaining
+     */
+    public CMSABuilder<S, I> withAgeMax(int ageMax) {
+        this.ageMax = ageMax;
+        return this;
+    }
+
+    /**
+     * Configures the time budget, in milliseconds, given to the solver at each iteration to solve
+     * the restricted sub-instance. Defaults to 1000 (1 second).
+     * @param solverTimeLimitInMillis time budget in milliseconds
+     * @return this builder instance for method chaining
+     */
+    public CMSABuilder<S, I> withSolverTimeLimitInMillis(long solverTimeLimitInMillis) {
+        this.solverTimeLimitInMillis = solverTimeLimitInMillis;
+        return this;
+    }
+
+    /**
+     * Configures the maximum number of iterations. Defaults to 0, disabling this limit and relying
+     * exclusively on the global time limit.
+     * @param maxIterations maximum number of iterations, use a value smaller or equal to zero to disable
+     * @return this builder instance for method chaining
+     */
+    public CMSABuilder<S, I> withMaxIterations(int maxIterations) {
+        this.maxIterations = maxIterations;
+        return this;
+    }
+
+    /**
+     * Optimize default objective function, which is the main objective declared in the current Context.
+     * Note that calling this method is optional, if the objective is not set it will default to the main objective.
+     * @return this builder instance for method chaining
+     */
+    public CMSABuilder<S, I> withDefaultObjective() {
+        this.objective = Context.getMainObjective();
+        return this;
+    }
+
+    /**
+     * Configures the objective function to optimize.
+     * @param objective objective function to optimize
+     * @return this builder instance for method chaining
+     */
+    public CMSABuilder<S, I> withObjective(Objective<?, S, I> objective) {
+        this.objective = objective;
+        return this;
+    }
+
+    /**
+     * Builds the CMSA algorithm with the configured parameters.
+     * Uses a random name for the algorithm.
+     * @return a new instance of CMSA
+     */
+    public CMSA<S, I> build() {
+        return this.build(StringUtil.randomAlgorithmName());
+    }
+
+    /**
+     * Builds the CMSA algorithm with the configured parameters.
+     * @param name algorithm name
+     * @return a new instance of CMSA
+     */
+    public CMSA<S, I> build(String name) {
+        Objective<?, S, I> resolvedObjective = this.objective == null ? Context.getMainObjective() : this.objective;
+
+        if (this.constructive == null) {
+            throw new IllegalArgumentException("CMSABuilder requires a CMSAConstructive implementation. Use .withConstructive() to configure it.");
+        }
+
+        if (this.solver == null) {
+            throw new IllegalArgumentException("CMSABuilder requires a CMSASolver implementation. Use .withSolver() to configure it.");
+        }
+
+        return new CMSA<>(name, resolvedObjective, constructive, solver, solutionsPerIteration, ageMax, solverTimeLimitInMillis, maxIterations);
+    }
+}

--- a/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSABuilder.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSABuilder.java
@@ -11,12 +11,13 @@ import es.urjc.etsii.grafo.util.StringUtil;
  *
  * @param <S> type of the solution of the problem
  * @param <I> type of the instance of the problem
+ * @param <C> type of the solution components
  */
-public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
+public class CMSABuilder<S extends Solution<S, I>, I extends Instance, C> {
 
     private Objective<?, S, I> objective;
-    private CMSAConstructive<S, I> constructive;
-    private CMSASolver<S, I> solver;
+    private CMSAConstructive<S, I, C> constructive;
+    private CMSASolver<S, I, C> solver;
     private int solutionsPerIteration = 30;
     private int ageMax = 5;
     private long solverTimeLimitInMillis = 1_000;
@@ -27,7 +28,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * @param constructive probabilistic constructive procedure
      * @return this builder instance for method chaining
      */
-    public CMSABuilder<S, I> withConstructive(CMSAConstructive<S, I> constructive) {
+    public CMSABuilder<S, I, C> withConstructive(CMSAConstructive<S, I, C> constructive) {
         this.constructive = constructive;
         return this;
     }
@@ -37,7 +38,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * @param solver exact method implementation
      * @return this builder instance for method chaining
      */
-    public CMSABuilder<S, I> withSolver(CMSASolver<S, I> solver) {
+    public CMSABuilder<S, I, C> withSolver(CMSASolver<S, I, C> solver) {
         this.solver = solver;
         return this;
     }
@@ -48,7 +49,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * @param solutionsPerIteration number of solutions constructed at each iteration, usually denoted {@code na}
      * @return this builder instance for method chaining
      */
-    public CMSABuilder<S, I> withSolutionsPerIteration(int solutionsPerIteration) {
+    public CMSABuilder<S, I, C> withSolutionsPerIteration(int solutionsPerIteration) {
         this.solutionsPerIteration = solutionsPerIteration;
         return this;
     }
@@ -59,7 +60,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * @param ageMax maximum component age
      * @return this builder instance for method chaining
      */
-    public CMSABuilder<S, I> withAgeMax(int ageMax) {
+    public CMSABuilder<S, I, C> withAgeMax(int ageMax) {
         this.ageMax = ageMax;
         return this;
     }
@@ -70,7 +71,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * @param solverTimeLimitInMillis time budget in milliseconds
      * @return this builder instance for method chaining
      */
-    public CMSABuilder<S, I> withSolverTimeLimitInMillis(long solverTimeLimitInMillis) {
+    public CMSABuilder<S, I, C> withSolverTimeLimitInMillis(long solverTimeLimitInMillis) {
         this.solverTimeLimitInMillis = solverTimeLimitInMillis;
         return this;
     }
@@ -81,7 +82,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * @param maxIterations maximum number of iterations, use a value smaller or equal to zero to disable
      * @return this builder instance for method chaining
      */
-    public CMSABuilder<S, I> withMaxIterations(int maxIterations) {
+    public CMSABuilder<S, I, C> withMaxIterations(int maxIterations) {
         this.maxIterations = maxIterations;
         return this;
     }
@@ -91,7 +92,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * Note that calling this method is optional, if the objective is not set it will default to the main objective.
      * @return this builder instance for method chaining
      */
-    public CMSABuilder<S, I> withDefaultObjective() {
+    public CMSABuilder<S, I, C> withDefaultObjective() {
         this.objective = Context.getMainObjective();
         return this;
     }
@@ -101,7 +102,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * @param objective objective function to optimize
      * @return this builder instance for method chaining
      */
-    public CMSABuilder<S, I> withObjective(Objective<?, S, I> objective) {
+    public CMSABuilder<S, I, C> withObjective(Objective<?, S, I> objective) {
         this.objective = objective;
         return this;
     }
@@ -111,7 +112,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * Uses a random name for the algorithm.
      * @return a new instance of CMSA
      */
-    public CMSA<S, I> build() {
+    public CMSA<S, I, C> build() {
         return this.build(StringUtil.randomAlgorithmName());
     }
 
@@ -120,7 +121,7 @@ public class CMSABuilder<S extends Solution<S, I>, I extends Instance> {
      * @param name algorithm name
      * @return a new instance of CMSA
      */
-    public CMSA<S, I> build(String name) {
+    public CMSA<S, I, C> build(String name) {
         Objective<?, S, I> resolvedObjective = this.objective == null ? Context.getMainObjective() : this.objective;
 
         if (this.constructive == null) {

--- a/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSAConstructive.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSAConstructive.java
@@ -21,8 +21,9 @@ import java.util.Set;
  *
  * @param <S> Solution class
  * @param <I> Instance class
+ * @param <C> Solution component class
  */
-public abstract class CMSAConstructive<S extends Solution<S, I>, I extends Instance> extends Constructive<S, I> {
+public abstract class CMSAConstructive<S extends Solution<S, I>, I extends Instance, C> extends Constructive<S, I> {
 
     /**
      * Returns the solution components used to build the given solution.
@@ -34,5 +35,5 @@ public abstract class CMSAConstructive<S extends Solution<S, I>, I extends Insta
      * @param solution a feasible solution to the problem
      * @return the set of solution components used in the given solution
      */
-    public abstract Set<Object> usedComponents(S solution);
+    public abstract Set<C> usedComponents(S solution);
 }

--- a/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSAConstructive.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSAConstructive.java
@@ -1,0 +1,38 @@
+package es.urjc.etsii.grafo.algorithms.cmsa;
+
+import es.urjc.etsii.grafo.create.Constructive;
+import es.urjc.etsii.grafo.io.Instance;
+import es.urjc.etsii.grafo.solution.Solution;
+
+import java.util.Set;
+
+/**
+ * Constructive method used by {@link CMSA} to probabilistically build complete solutions.
+ * Solutions built by this method are only used to sample which solution components (edges, assignments,
+ * items, etc.) look promising: they are never returned as the algorithm result directly.
+ * <p>
+ * Besides building a solution as any other {@link Constructive}, implementations must be able to identify
+ * which solution components were used to build a given solution, so {@link CMSA} can add them to the
+ * restricted sub-instance solved at every iteration, and track their age.
+ * <p>
+ * Solution components can be represented using any type that correctly implements {@code equals} and
+ * {@code hashCode}, for example a record such as {@code record Edge(int from, int to)}, or an autoboxed
+ * primitive such as {@code Integer} when components are simply indexes.
+ *
+ * @param <S> Solution class
+ * @param <I> Instance class
+ */
+public abstract class CMSAConstructive<S extends Solution<S, I>, I extends Instance> extends Constructive<S, I> {
+
+    /**
+     * Returns the solution components used to build the given solution.
+     * This method is usually called immediately after {@link #construct(Solution)},
+     * but implementations should not assume this and must be able to work with any
+     * feasible solution to the problem, as it is also used to identify which components
+     * are part of the solution returned by the {@link CMSASolver}.
+     *
+     * @param solution a feasible solution to the problem
+     * @return the set of solution components used in the given solution
+     */
+    public abstract Set<Object> usedComponents(S solution);
+}

--- a/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSASolver.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSASolver.java
@@ -1,0 +1,51 @@
+package es.urjc.etsii.grafo.algorithms.cmsa;
+
+import es.urjc.etsii.grafo.annotations.AlgorithmComponent;
+import es.urjc.etsii.grafo.io.Instance;
+import es.urjc.etsii.grafo.solution.Solution;
+
+import java.util.Set;
+
+/**
+ * Solves, exactly or as close to exactly as possible, the sub-instance of the problem induced by restricting
+ * it to a given set of solution components. This is the "Solve" step of the CMSA (Construct, Merge, Solve
+ * and Adapt) algorithm, see {@link CMSA} for more details about the whole procedure.
+ * <p>
+ * Mork does not bundle any exact solver: implementations of this class are expected to encode the restricted
+ * sub-instance and delegate to whatever exact method fits the problem and is available in the classpath,
+ * for example a MIP/ILP solver such as CPLEX, Gurobi, SCIP or OR-Tools, a specialized dynamic programming
+ * procedure, or, when the restricted sub-instance is small enough as it is expected in CMSA, an exhaustive
+ * branch and bound search.
+ * <p>
+ * For guidance on how to formulate the mathematical (MIP/ILP) model of the restricted sub-instance for a
+ * given problem, see:
+ * Blum, C. (2024). Construct, Merge, Solve &amp; Adapt: A Hybrid Metaheuristic for Combinatorial Optimization.
+ * Computational Intelligence Methods and Applications. Springer.
+ * <a href="https://doi.org/10.1007/978-3-031-60103-3">...</a>
+ *
+ * @param <S> Solution class
+ * @param <I> Instance class
+ */
+@AlgorithmComponent
+public abstract class CMSASolver<S extends Solution<S, I>, I extends Instance> {
+
+    /**
+     * Solves the sub-instance induced by restricting the problem to the given set of solution components.
+     * Implementations are free to return a suboptimal solution if the time limit is reached before
+     * the sub-instance is solved to optimality, but the returned solution, if any, must always be feasible.
+     *
+     * @param instance              original problem instance
+     * @param restrictedComponents  set of solution components the returned solution is restricted to use.
+     *                              Values are the same objects returned by {@link CMSAConstructive#usedComponents(Solution)}
+     * @param maxDurationInMillis   maximum time budget, in milliseconds, to spend solving the sub-instance
+     * @return a feasible solution built only using components in {@code restrictedComponents},
+     *         or {@code null} if no feasible solution could be found in the given time budget
+     */
+    public abstract S solve(I instance, Set<Object> restrictedComponents, long maxDurationInMillis);
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "{}";
+    }
+}

--- a/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSASolver.java
+++ b/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSASolver.java
@@ -25,9 +25,10 @@ import java.util.Set;
  *
  * @param <S> Solution class
  * @param <I> Instance class
+ * @param <C> Solution component class
  */
 @AlgorithmComponent
-public abstract class CMSASolver<S extends Solution<S, I>, I extends Instance> {
+public abstract class CMSASolver<S extends Solution<S, I>, I extends Instance, C> {
 
     /**
      * Solves the sub-instance induced by restricting the problem to the given set of solution components.
@@ -41,7 +42,7 @@ public abstract class CMSASolver<S extends Solution<S, I>, I extends Instance> {
      * @return a feasible solution built only using components in {@code restrictedComponents},
      *         or {@code null} if no feasible solution could be found in the given time budget
      */
-    public abstract S solve(I instance, Set<Object> restrictedComponents, long maxDurationInMillis);
+    public abstract S solve(I instance, Set<C> restrictedComponents, long maxDurationInMillis);
 
     /** {@inheritDoc} */
     @Override

--- a/common/src/test/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSATest.java
+++ b/common/src/test/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSATest.java
@@ -1,0 +1,216 @@
+package es.urjc.etsii.grafo.algorithms.cmsa;
+
+import es.urjc.etsii.grafo.create.builder.SolutionBuilder;
+import es.urjc.etsii.grafo.metrics.Metrics;
+import es.urjc.etsii.grafo.solution.Objective;
+import es.urjc.etsii.grafo.testutil.TestInstance;
+import es.urjc.etsii.grafo.testutil.TestMove;
+import es.urjc.etsii.grafo.testutil.TestSolution;
+import es.urjc.etsii.grafo.util.Context;
+import es.urjc.etsii.grafo.util.TimeControl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class CMSATest {
+
+    private final TestInstance testInstance = new TestInstance("testinstance");
+
+    @BeforeAll
+    public static void init() {
+        Metrics.disableMetrics();
+        Context.Configurator.setObjectives(Objective.ofMinimizing("Test", TestSolution::getScore, TestMove::getScoreChange));
+    }
+
+    @AfterEach
+    void cleanup() {
+        TimeControl.remove();
+    }
+
+    private CMSABuilder<TestSolution, TestInstance> builder() {
+        return new CMSABuilder<TestSolution, TestInstance>()
+                .withDefaultObjective()
+                .withSolutionsPerIteration(1)
+                .withAgeMax(5)
+                .withSolverTimeLimitInMillis(1000);
+    }
+
+    private void withBuilder(CMSA<TestSolution, TestInstance> cmsa) {
+        cmsa.setBuilder(new SolutionBuilder<>() {
+            @Override
+            public TestSolution initializeSolution(TestInstance instance) {
+                return new TestSolution(instance);
+            }
+        });
+    }
+
+    @Test
+    void testIllegalParameters() {
+        @SuppressWarnings("unchecked")
+        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        @SuppressWarnings("unchecked")
+        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        Objective<?, TestSolution, TestInstance> objective = Context.getMainObjective();
+
+        Assertions.assertDoesNotThrow(() ->
+                new CMSA<>("Test", objective, constructive, solver, 1, 0, 1, 10));
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                new CMSA<>("Test", objective, constructive, solver, 0, 0, 1, 10));
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                new CMSA<>("Test", objective, constructive, solver, 1, -1, 1, 10));
+
+        Assertions.assertThrows(IllegalArgumentException.class, () ->
+                new CMSA<>("Test", objective, constructive, solver, 1, 0, 0, 10));
+    }
+
+    @Test
+    void testBuilderRequiresConstructiveAndSolver() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new CMSABuilder<TestSolution, TestInstance>().build());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testStopsAtMaxIterations() {
+        var solution = new TestSolution(testInstance, 10);
+        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        when(constructive.construct(any(TestSolution.class))).thenReturn(solution);
+        when(constructive.usedComponents(any(TestSolution.class))).thenReturn(Set.of("c1"));
+
+        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        when(solver.solve(eq(testInstance), anySet(), anyLong())).thenReturn(solution);
+
+        int maxIterations = 5;
+        var cmsa = builder().withConstructive(constructive).withSolver(solver).withMaxIterations(maxIterations).build("Test");
+        withBuilder(cmsa);
+
+        var result = cmsa.algorithm(testInstance);
+
+        Assertions.assertEquals(solution, result);
+        verify(solver, times(maxIterations)).solve(eq(testInstance), anySet(), anyLong());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testKeepsBestSolutionFoundAcrossIterations() {
+        var worse = new TestSolution(testInstance, 20);
+        var best = new TestSolution(testInstance, 5);
+        var worseAgain = new TestSolution(testInstance, 15);
+
+        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        when(constructive.construct(any(TestSolution.class))).thenReturn(worse);
+        when(constructive.usedComponents(any(TestSolution.class))).thenReturn(Set.of("c1"));
+
+        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        when(solver.solve(eq(testInstance), anySet(), anyLong())).thenReturn(worse, best, worseAgain);
+
+        var cmsa = builder().withConstructive(constructive).withSolver(solver).withMaxIterations(3).build("Test");
+        withBuilder(cmsa);
+
+        var result = cmsa.algorithm(testInstance);
+
+        Assertions.assertEquals(best, result);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testThrowsWhenSolverNeverFindsAFeasibleSolution() {
+        var solution = new TestSolution(testInstance, 10);
+        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        when(constructive.construct(any(TestSolution.class))).thenReturn(solution);
+        when(constructive.usedComponents(any(TestSolution.class))).thenReturn(Set.of("c1"));
+
+        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        when(solver.solve(eq(testInstance), anySet(), anyLong())).thenReturn(null);
+
+        var cmsa = builder().withConstructive(constructive).withSolver(solver).withMaxIterations(3).build("Test");
+        withBuilder(cmsa);
+
+        Assertions.assertThrows(IllegalStateException.class, () -> cmsa.algorithm(testInstance));
+    }
+
+    @Test
+    void testStopByMaxTime() {
+        var solution = new TestSolution(testInstance, 10);
+        @SuppressWarnings("unchecked")
+        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        when(constructive.construct(any(TestSolution.class))).thenReturn(solution);
+        when(constructive.usedComponents(any(TestSolution.class))).thenReturn(Set.of("c1"));
+
+        @SuppressWarnings("unchecked")
+        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        when(solver.solve(eq(testInstance), anySet(), anyLong())).thenReturn(solution);
+
+        TimeControl.setMaxExecutionTime(10, TimeUnit.MILLISECONDS);
+        TimeControl.start();
+
+        var cmsa = builder().withConstructive(constructive).withSolver(solver).withMaxIterations(10_000_000).build("Test");
+        withBuilder(cmsa);
+
+        long startTime = System.nanoTime();
+        cmsa.algorithm(testInstance);
+        long elapsedMillis = (System.nanoTime() - startTime) / 1_000_000;
+
+        Assertions.assertTrue(elapsedMillis < 500, "Does not stop shortly after the time budget is exhausted");
+    }
+
+    /**
+     * Verifies the "Adapt" step: components that keep being selected by the solver stay in the
+     * sub-instance, while components that are consistently ignored age out and get dropped once
+     * their age exceeds ageMax, keeping the size of the restricted sub-instance bounded.
+     */
+    @Test
+    void testAdaptDropsStaleComponents() {
+        int ageMax = 2;
+        int iterations = 8;
+        AtomicInteger counter = new AtomicInteger();
+
+        var constructive = new CMSAConstructive<TestSolution, TestInstance>() {
+            @Override
+            public TestSolution construct(TestSolution solution) {
+                return solution;
+            }
+
+            @Override
+            public Set<Object> usedComponents(TestSolution solution) {
+                // Every constructed solution introduces exactly one new, never-repeated component
+                return Set.of("component-" + counter.getAndIncrement());
+            }
+        };
+
+        Deque<Set<Object>> capturedRestrictions = new ArrayDeque<>();
+        var solver = new CMSASolver<TestSolution, TestInstance>() {
+            @Override
+            public TestSolution solve(TestInstance instance, Set<Object> restrictedComponents, long maxDurationInMillis) {
+                capturedRestrictions.add(new HashSet<>(restrictedComponents));
+                // Never selects any component: everything currently in the sub-instance ages this round
+                return new TestSolution(instance, 1);
+            }
+        };
+
+        var cmsa = builder().withConstructive(constructive).withSolver(solver)
+                .withAgeMax(ageMax).withMaxIterations(iterations).build("Test");
+        withBuilder(cmsa);
+
+        cmsa.algorithm(testInstance);
+
+        Assertions.assertEquals(iterations, capturedRestrictions.size());
+        // Sub-instance size grows until it reaches steady state at ageMax + 1, then stays bounded
+        var lastRestriction = capturedRestrictions.getLast();
+        Assertions.assertEquals(ageMax + 1, lastRestriction.size(),
+                "Sub-instance size should stabilize at ageMax + 1 once components start aging out");
+    }
+}

--- a/common/src/test/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSATest.java
+++ b/common/src/test/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSATest.java
@@ -39,15 +39,15 @@ class CMSATest {
         TimeControl.remove();
     }
 
-    private CMSABuilder<TestSolution, TestInstance> builder() {
-        return new CMSABuilder<TestSolution, TestInstance>()
+    private CMSABuilder<TestSolution, TestInstance, String> builder() {
+        return new CMSABuilder<TestSolution, TestInstance, String>()
                 .withDefaultObjective()
                 .withSolutionsPerIteration(1)
                 .withAgeMax(5)
                 .withSolverTimeLimitInMillis(1000);
     }
 
-    private void withBuilder(CMSA<TestSolution, TestInstance> cmsa) {
+    private void withBuilder(CMSA<TestSolution, TestInstance, String> cmsa) {
         cmsa.setBuilder(new SolutionBuilder<>() {
             @Override
             public TestSolution initializeSolution(TestInstance instance) {
@@ -59,9 +59,9 @@ class CMSATest {
     @Test
     void testIllegalParameters() {
         @SuppressWarnings("unchecked")
-        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        CMSAConstructive<TestSolution, TestInstance, String> constructive = mock(CMSAConstructive.class);
         @SuppressWarnings("unchecked")
-        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        CMSASolver<TestSolution, TestInstance, String> solver = mock(CMSASolver.class);
         Objective<?, TestSolution, TestInstance> objective = Context.getMainObjective();
 
         Assertions.assertDoesNotThrow(() ->
@@ -79,18 +79,18 @@ class CMSATest {
 
     @Test
     void testBuilderRequiresConstructiveAndSolver() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> new CMSABuilder<TestSolution, TestInstance>().build());
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new CMSABuilder<TestSolution, TestInstance, String>().build());
     }
 
     @Test
     @SuppressWarnings("unchecked")
     void testStopsAtMaxIterations() {
         var solution = new TestSolution(testInstance, 10);
-        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        CMSAConstructive<TestSolution, TestInstance, String> constructive = mock(CMSAConstructive.class);
         when(constructive.construct(any(TestSolution.class))).thenReturn(solution);
         when(constructive.usedComponents(any(TestSolution.class))).thenReturn(Set.of("c1"));
 
-        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        CMSASolver<TestSolution, TestInstance, String> solver = mock(CMSASolver.class);
         when(solver.solve(eq(testInstance), anySet(), anyLong())).thenReturn(solution);
 
         int maxIterations = 5;
@@ -110,11 +110,11 @@ class CMSATest {
         var best = new TestSolution(testInstance, 5);
         var worseAgain = new TestSolution(testInstance, 15);
 
-        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        CMSAConstructive<TestSolution, TestInstance, String> constructive = mock(CMSAConstructive.class);
         when(constructive.construct(any(TestSolution.class))).thenReturn(worse);
         when(constructive.usedComponents(any(TestSolution.class))).thenReturn(Set.of("c1"));
 
-        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        CMSASolver<TestSolution, TestInstance, String> solver = mock(CMSASolver.class);
         when(solver.solve(eq(testInstance), anySet(), anyLong())).thenReturn(worse, best, worseAgain);
 
         var cmsa = builder().withConstructive(constructive).withSolver(solver).withMaxIterations(3).build("Test");
@@ -129,11 +129,11 @@ class CMSATest {
     @SuppressWarnings("unchecked")
     void testThrowsWhenSolverNeverFindsAFeasibleSolution() {
         var solution = new TestSolution(testInstance, 10);
-        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        CMSAConstructive<TestSolution, TestInstance, String> constructive = mock(CMSAConstructive.class);
         when(constructive.construct(any(TestSolution.class))).thenReturn(solution);
         when(constructive.usedComponents(any(TestSolution.class))).thenReturn(Set.of("c1"));
 
-        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        CMSASolver<TestSolution, TestInstance, String> solver = mock(CMSASolver.class);
         when(solver.solve(eq(testInstance), anySet(), anyLong())).thenReturn(null);
 
         var cmsa = builder().withConstructive(constructive).withSolver(solver).withMaxIterations(3).build("Test");
@@ -146,12 +146,12 @@ class CMSATest {
     void testStopByMaxTime() {
         var solution = new TestSolution(testInstance, 10);
         @SuppressWarnings("unchecked")
-        CMSAConstructive<TestSolution, TestInstance> constructive = mock(CMSAConstructive.class);
+        CMSAConstructive<TestSolution, TestInstance, String> constructive = mock(CMSAConstructive.class);
         when(constructive.construct(any(TestSolution.class))).thenReturn(solution);
         when(constructive.usedComponents(any(TestSolution.class))).thenReturn(Set.of("c1"));
 
         @SuppressWarnings("unchecked")
-        CMSASolver<TestSolution, TestInstance> solver = mock(CMSASolver.class);
+        CMSASolver<TestSolution, TestInstance, String> solver = mock(CMSASolver.class);
         when(solver.solve(eq(testInstance), anySet(), anyLong())).thenReturn(solution);
 
         TimeControl.setMaxExecutionTime(10, TimeUnit.MILLISECONDS);
@@ -178,23 +178,23 @@ class CMSATest {
         int iterations = 8;
         AtomicInteger counter = new AtomicInteger();
 
-        var constructive = new CMSAConstructive<TestSolution, TestInstance>() {
+        var constructive = new CMSAConstructive<TestSolution, TestInstance, String>() {
             @Override
             public TestSolution construct(TestSolution solution) {
                 return solution;
             }
 
             @Override
-            public Set<Object> usedComponents(TestSolution solution) {
+            public Set<String> usedComponents(TestSolution solution) {
                 // Every constructed solution introduces exactly one new, never-repeated component
                 return Set.of("component-" + counter.getAndIncrement());
             }
         };
 
-        Deque<Set<Object>> capturedRestrictions = new ArrayDeque<>();
-        var solver = new CMSASolver<TestSolution, TestInstance>() {
+        Deque<Set<String>> capturedRestrictions = new ArrayDeque<>();
+        var solver = new CMSASolver<TestSolution, TestInstance, String>() {
             @Override
-            public TestSolution solve(TestInstance instance, Set<Object> restrictedComponents, long maxDurationInMillis) {
+            public TestSolution solve(TestInstance instance, Set<String> restrictedComponents, long maxDurationInMillis) {
                 capturedRestrictions.add(new HashSet<>(restrictedComponents));
                 // Never selects any component: everything currently in the sub-instance ages this round
                 return new TestSolution(instance, 1);

--- a/docs/concepts/algorithm-components/components.md
+++ b/docs/concepts/algorithm-components/components.md
@@ -13,6 +13,7 @@ High-level algorithmic strategies that guide the search process. These are the m
 | **Iterated Greedy (IG)** | Destruction-reconstruction metaheuristic that iteratively destroys and rebuilds solutions | [IG Documentation](metaheuristics/iterated-greedy.md) |
 | **Scatter Search** | Population-based metaheuristic using reference sets and solution combination | [Scatter Search Documentation](metaheuristics/scatter-search.md) |
 | **Multi-Start Algorithm** | Simple but effective strategy that runs constructive+improvement methods multiple times | [Multi-Start Documentation](metaheuristics/multi-start.md) |
+| **CMSA (Construct, Merge, Solve & Adapt)** | Matheuristic that repeatedly solves a small, adaptively-selected sub-instance with an exact method | [CMSA Documentation](metaheuristics/cmsa.md) |
 
 ## Constructive Methods
 

--- a/docs/concepts/algorithm-components/metaheuristics/.pages
+++ b/docs/concepts/algorithm-components/metaheuristics/.pages
@@ -6,3 +6,4 @@ nav:
     - scatter-search.md
     - multi-start.md
     - vnd.md
+    - cmsa.md

--- a/docs/concepts/algorithm-components/metaheuristics/cmsa.md
+++ b/docs/concepts/algorithm-components/metaheuristics/cmsa.md
@@ -1,0 +1,103 @@
+# CMSA (Construct, Merge, Solve & Adapt)
+
+CMSA is a hybrid matheuristic that combines a probabilistic constructive heuristic with an exact method. Instead of applying the exact method to the whole problem instance, which is usually intractable, CMSA repeatedly restricts the search to a small, promising subset of solution components (an edge, an item-to-bin assignment, etc.), and solves that much smaller sub-instance to optimality (or as close to optimality as possible) at every iteration.
+
+For further information about CMSA see: Blum, C., Pinacho, P., López-Ibáñez, M., & Lozano, J. A. (2016). Construct, Merge, Solve and Adapt: A new algorithm for combinatorial optimization. Computers & Operations Research, 68, 75-88. [https://doi.org/10.1016/j.cor.2015.10.014](https://doi.org/10.1016/j.cor.2015.10.014)
+
+For an in-depth treatment of CMSA, including guidance on modelling the sub-instance solved at every iteration for different combinatorial optimization problems, see: Blum, C. (2024). Construct, Merge, Solve & Adapt: A Hybrid Metaheuristic for Combinatorial Optimization. Computational Intelligence Methods and Applications. Springer. [https://doi.org/10.1007/978-3-031-60103-3](https://doi.org/10.1007/978-3-031-60103-3)
+
+## Algorithm Overview
+
+```mermaid
+graph TD
+    A[Csub = empty sub-instance] --> B[Construct na solutions]
+    B --> C[Merge: add new components used by each solution into Csub, age = 0]
+    C --> D[Solve: exactly solve the sub-instance restricted to Csub]
+    D --> E{Better than Sbest?}
+    E -->|Yes| F[Sbest = solved solution]
+    E -->|No| G[Adapt]
+    F --> G
+    G --> H[Components used by the solver: age = 0]
+    G --> I[Other components: age += 1, drop if age > ageMax]
+    H --> J{Stopping criteria?}
+    I --> J
+    J -->|No| B
+    J -->|Yes| K[Return Sbest]
+```
+
+## Algorithm Outline
+
+```
+Csub = {}          // sub-instance: solution components with a chance of being part of a good solution
+Sbest = null
+repeat until stopping criterion is met:
+    // Construct & Merge
+    for na times:
+        S' = ProbabilisticConstruct(instance)
+        Csub = Csub U usedComponents(S')       // merge new components into the sub-instance, age = 0
+
+    // Solve
+    S* = Solve(instance restricted to Csub)    // exact method, e.g. ILP solver, DP, branch and bound
+    if S* is better than Sbest: Sbest = S*
+
+    // Adapt
+    for each component c in Csub:
+        if c in S*: age(c) = 0
+        else:
+            age(c) = age(c) + 1
+            if age(c) > ageMax: Csub = Csub \ {c}
+
+return Sbest
+```
+
+Components that keep being selected by the exact method stay in `Csub` indefinitely, since their age is reset to zero every time they are chosen again. Components that are no longer useful eventually age out and are dropped, which keeps the sub-instance small across iterations. This adaptive behaviour is what gives CMSA its name, and what makes it different from just repeatedly solving a brand new random restricted sub-instance from scratch at every iteration: the sub-instance progressively evolves towards the components that matter for a good solution.
+
+## Mork implementation
+
+CMSA is implemented in [`CMSA`](https://github.com/rmartinsanta/mork/blob/master/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSA.java), and depends on two problem-specific components:
+
+- [`CMSAConstructive`](https://github.com/rmartinsanta/mork/blob/master/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSAConstructive.java): a regular [`Constructive`](../constructors) that additionally knows how to extract the set of solution components used by any given solution. Solution components can be represented using any type that properly implements `equals`/`hashCode`, for example a record such as `record Edge(int from, int to)`.
+- [`CMSASolver`](https://github.com/rmartinsanta/mork/blob/master/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSASolver.java): solves, exactly or as close to exactly as possible, the sub-instance induced by a given set of solution components, within a time budget.
+
+!!! info
+    Mork does not bundle any exact solver. `CMSASolver` implementations are expected to encode the restricted sub-instance and delegate to whatever exact method is available and fits the problem: a MIP/ILP solver such as CPLEX, Gurobi, SCIP or OR-Tools, a specialized dynamic programming procedure, or, since the restricted sub-instance is expected to stay small thanks to the aging mechanism, an exhaustive branch and bound search.
+
+```java
+public class MyCMSAConstructive extends CMSAConstructive<MySolution, MyInstance> {
+    @Override
+    public MySolution construct(MySolution solution) {
+        // Biased-randomized / probabilistic construction, similar to a GRASP constructive
+        // but usually with more randomization, as the goal is to sample good components, not
+        // to build the best possible single solution.
+        ...
+        return solution;
+    }
+
+    @Override
+    public Set<Object> usedComponents(MySolution solution) {
+        // Return the components (edges, assignments, etc.) used in the given solution
+        return solution.usedEdges();
+    }
+}
+
+public class MyCMSASolver extends CMSASolver<MySolution, MyInstance> {
+    @Override
+    public MySolution solve(MyInstance instance, Set<Object> restrictedComponents, long maxDurationInMillis) {
+        // Build and solve the sub-instance induced by restrictedComponents, e.g. calling an ILP solver
+        ...
+    }
+}
+```
+
+A `CMSA` instance can be built directly, or using `CMSABuilder`:
+
+```java
+var cmsa = new CMSABuilder<MySolution, MyInstance>()
+        .withConstructive(new MyCMSAConstructive())
+        .withSolver(new MyCMSASolver())
+        .withSolutionsPerIteration(30) // na
+        .withAgeMax(5)
+        .withSolverTimeLimitInMillis(1000)
+        .withMaxIterations(1000)
+        .build();
+```

--- a/docs/concepts/algorithm-components/metaheuristics/cmsa.md
+++ b/docs/concepts/algorithm-components/metaheuristics/cmsa.md
@@ -63,7 +63,7 @@ CMSA is implemented in [`CMSA`](https://github.com/rmartinsanta/mork/blob/master
     Mork does not bundle any exact solver. `CMSASolver` implementations are expected to encode the restricted sub-instance and delegate to whatever exact method is available and fits the problem: a MIP/ILP solver such as CPLEX, Gurobi, SCIP or OR-Tools, a specialized dynamic programming procedure, or, since the restricted sub-instance is expected to stay small thanks to the aging mechanism, an exhaustive branch and bound search.
 
 ```java
-public class MyCMSAConstructive extends CMSAConstructive<MySolution, MyInstance> {
+public class MyCMSAConstructive extends CMSAConstructive<MySolution, MyInstance, Edge> {
     @Override
     public MySolution construct(MySolution solution) {
         // Biased-randomized / probabilistic construction, similar to a GRASP constructive
@@ -74,15 +74,15 @@ public class MyCMSAConstructive extends CMSAConstructive<MySolution, MyInstance>
     }
 
     @Override
-    public Set<Object> usedComponents(MySolution solution) {
+    public Set<Edge> usedComponents(MySolution solution) {
         // Return the components (edges, assignments, etc.) used in the given solution
         return solution.usedEdges();
     }
 }
 
-public class MyCMSASolver extends CMSASolver<MySolution, MyInstance> {
+public class MyCMSASolver extends CMSASolver<MySolution, MyInstance, Edge> {
     @Override
-    public MySolution solve(MyInstance instance, Set<Object> restrictedComponents, long maxDurationInMillis) {
+    public MySolution solve(MyInstance instance, Set<Edge> restrictedComponents, long maxDurationInMillis) {
         // Build and solve the sub-instance induced by restrictedComponents, e.g. calling an ILP solver
         ...
     }
@@ -92,7 +92,7 @@ public class MyCMSASolver extends CMSASolver<MySolution, MyInstance> {
 A `CMSA` instance can be built directly, or using `CMSABuilder`:
 
 ```java
-var cmsa = new CMSABuilder<MySolution, MyInstance>()
+var cmsa = new CMSABuilder<MySolution, MyInstance, Edge>()
         .withConstructive(new MyCMSAConstructive())
         .withSolver(new MyCMSASolver())
         .withSolutionsPerIteration(30) // na

--- a/docs/concepts/algorithm-components/metaheuristics/cmsa.md
+++ b/docs/concepts/algorithm-components/metaheuristics/cmsa.md
@@ -54,10 +54,10 @@ Components that keep being selected by the exact method stay in `Csub` indefinit
 
 ## Mork implementation
 
-CMSA is implemented in [`CMSA`](https://github.com/rmartinsanta/mork/blob/master/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSA.java), and depends on two problem-specific components:
+CMSA is implemented in [`CMSA`](../../../apidocs/es/urjc/etsii/grafo/algorithms/cmsa/CMSA.html), and depends on two problem-specific components:
 
-- [`CMSAConstructive`](https://github.com/rmartinsanta/mork/blob/master/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSAConstructive.java): a regular [`Constructive`](../constructors) that additionally knows how to extract the set of solution components used by any given solution. Solution components can be represented using any type that properly implements `equals`/`hashCode`, for example a record such as `record Edge(int from, int to)`.
-- [`CMSASolver`](https://github.com/rmartinsanta/mork/blob/master/common/src/main/java/es/urjc/etsii/grafo/algorithms/cmsa/CMSASolver.java): solves, exactly or as close to exactly as possible, the sub-instance induced by a given set of solution components, within a time budget.
+- [`CMSAConstructive`](../../../apidocs/es/urjc/etsii/grafo/algorithms/cmsa/CMSAConstructive.html): a regular [`Constructive`](../constructors) that additionally knows how to extract the set of solution components used by any given solution. Solution components can be represented using any type that properly implements `equals`/`hashCode`, for example a record such as `record Edge(int from, int to)`.
+- [`CMSASolver`](../../../apidocs/es/urjc/etsii/grafo/algorithms/cmsa/CMSASolver.html): solves, exactly or as close to exactly as possible, the sub-instance induced by a given set of solution components, within a time budget.
 
 !!! info
     Mork does not bundle any exact solver. `CMSASolver` implementations are expected to encode the restricted sub-instance and delegate to whatever exact method is available and fits the problem: a MIP/ILP solver such as CPLEX, Gurobi, SCIP or OR-Tools, a specialized dynamic programming procedure, or, since the restricted sub-instance is expected to stay small thanks to the aging mechanism, an exhaustive branch and bound search.

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/Main.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/Main.java
@@ -7,10 +7,11 @@ import es.urjc.etsii.grafo.solver.Mork;
 
 public class Main {
 
-    // Multiple "easy" graph problems are grouped in the same project as a demo
-    // - MST: Minimum Spanning Tree
-    // - SP: Shortest Paths
-    // All reuse the same objective (minimize a double value)
+    // Multiple graph problems are grouped in the same project as a demo
+    // - MST: Minimum Spanning Tree (easy, exact algorithms: Kruskal, Prim)
+    // - SP: Shortest Paths (easy, exact algorithm: Dijkstra, Floyd-Warshall)
+    // - MVC: Minimum Vertex Cover (NP-hard, solved with the CMSA metaheuristic)
+    // All reuse the same objective (minimize a double value) and solution class
     public static final Objective<?, MSTSolution, MSTInstance> OBJECTIVE =
             Objective.ofMinimizing("Score", MSTSolution::getScore, null);
 

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/experiments/MinVertexCoverExp.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/experiments/MinVertexCoverExp.java
@@ -21,7 +21,7 @@ public class MinVertexCoverExp extends AbstractExperiment<MSTSolution, MSTInstan
 
     @Override
     public List<Algorithm<MSTSolution, MSTInstance>> getAlgorithms() {
-        var cmsa = new CMSABuilder<MSTSolution, MSTInstance>()
+        var cmsa = new CMSABuilder<MSTSolution, MSTInstance, Integer>()
                 .withDefaultObjective()
                 .withConstructive(new MVCConstructive())
                 .withSolver(new MVCExactCoverSolver())

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/experiments/MinVertexCoverExp.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/experiments/MinVertexCoverExp.java
@@ -1,0 +1,36 @@
+package es.urjc.etsii.grafo.graphs.experiments;
+
+import es.urjc.etsii.grafo.algorithms.Algorithm;
+import es.urjc.etsii.grafo.algorithms.cmsa.CMSABuilder;
+import es.urjc.etsii.grafo.experiment.AbstractExperiment;
+import es.urjc.etsii.grafo.graphs.model.MSTInstance;
+import es.urjc.etsii.grafo.graphs.model.MSTSolution;
+import es.urjc.etsii.grafo.graphs.mvc.MVCConstructive;
+import es.urjc.etsii.grafo.graphs.mvc.MVCExactCoverSolver;
+
+import java.util.List;
+
+/**
+ * Minimum Vertex Cover (MVC), solved with CMSA (Construct, Merge, Solve &amp; Adapt).
+ * Unlike MST/Shortest Paths, MVC is NP-hard: there is no known polynomial exact algorithm,
+ * which is exactly the kind of problem CMSA targets. See {@link MVCConstructive} for the
+ * probabilistic construction used to sample candidate vertices, and {@link MVCExactCoverSolver}
+ * for the exact method used to solve the restricted sub-instance at every iteration.
+ */
+public class MinVertexCoverExp extends AbstractExperiment<MSTSolution, MSTInstance> {
+
+    @Override
+    public List<Algorithm<MSTSolution, MSTInstance>> getAlgorithms() {
+        var cmsa = new CMSABuilder<MSTSolution, MSTInstance>()
+                .withDefaultObjective()
+                .withConstructive(new MVCConstructive())
+                .withSolver(new MVCExactCoverSolver())
+                .withSolutionsPerIteration(20)
+                .withAgeMax(5)
+                .withSolverTimeLimitInMillis(200)
+                .withMaxIterations(200)
+                .build("CMSA-MVC");
+
+        return List.of(cmsa);
+    }
+}

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/model/MSTSolution.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/model/MSTSolution.java
@@ -2,11 +2,21 @@ package es.urjc.etsii.grafo.graphs.model;
 
 import es.urjc.etsii.grafo.solution.Solution;
 
+import java.util.BitSet;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class MSTSolution extends Solution<MSTSolution, MSTInstance> {
 
     private double score;
+
+    /**
+     * Selected vertices, only used by the Minimum Vertex Cover (MVC) demo.
+     * Left empty by every other algorithm in this project.
+     */
+    private final BitSet cover;
+
     /**
      * Initialize solution from instance
      *
@@ -15,6 +25,7 @@ public class MSTSolution extends Solution<MSTSolution, MSTInstance> {
     public MSTSolution(MSTInstance instance) {
         super(instance);
         score = 0;
+        this.cover = new BitSet(instance.v());
     }
 
     /**
@@ -25,6 +36,7 @@ public class MSTSolution extends Solution<MSTSolution, MSTInstance> {
     public MSTSolution(MSTSolution solution) {
         super(solution);
         this.score = solution.score;
+        this.cover = (BitSet) solution.cover.clone();
     }
 
 
@@ -75,5 +87,50 @@ public class MSTSolution extends Solution<MSTSolution, MSTInstance> {
                 score += d[i][j];
             }
         }
+    }
+
+    /**
+     * Is the given vertex part of the vertex cover? Only meaningful for the MVC demo.
+     * @param vertex vertex id
+     * @return true if the vertex is currently selected
+     */
+    public boolean isInCover(int vertex) {
+        return this.cover.get(vertex);
+    }
+
+    /**
+     * Add a vertex to the vertex cover. Only meaningful for the MVC demo.
+     * @param vertex vertex id
+     */
+    public void addToCover(int vertex) {
+        this.cover.set(vertex);
+    }
+
+    /**
+     * Vertices currently selected as part of the vertex cover. Only meaningful for the MVC demo.
+     * @return a new set with the selected vertex ids
+     */
+    public Set<Integer> getCoverVertices() {
+        var result = new HashSet<Integer>();
+        for (int v = this.cover.nextSetBit(0); v >= 0; v = this.cover.nextSetBit(v + 1)) {
+            result.add(v);
+        }
+        return result;
+    }
+
+    /**
+     * Number of vertices currently selected as part of the vertex cover.
+     * @return cover size
+     */
+    public int getCoverSize() {
+        return this.cover.cardinality();
+    }
+
+    /**
+     * Set the solution score to the current vertex cover size. Only meaningful for the MVC demo,
+     * as the MVC objective is to minimize the number of selected vertices.
+     */
+    public void setScoreCover() {
+        score = this.cover.cardinality();
     }
 }

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructive.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructive.java
@@ -1,0 +1,89 @@
+package es.urjc.etsii.grafo.graphs.mvc;
+
+import es.urjc.etsii.grafo.algorithms.cmsa.CMSAConstructive;
+import es.urjc.etsii.grafo.graphs.model.Edge;
+import es.urjc.etsii.grafo.graphs.model.MSTInstance;
+import es.urjc.etsii.grafo.graphs.model.MSTSolution;
+import es.urjc.etsii.grafo.util.random.RandomManager;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.random.RandomGenerator;
+
+/**
+ * Probabilistic constructive method for the Minimum Vertex Cover (MVC) problem, used as the
+ * "Construct" step of the CMSA demo in this project.
+ * <p>
+ * Repeatedly picks a random still-uncovered edge, and adds one of its endpoints to the cover,
+ * biased towards the endpoint with the highest remaining degree (as in the classic greedy vertex
+ * cover heuristic), but not always: this randomization is what allows CMSA to sample different,
+ * varied vertex subsets across iterations to build the sub-instance.
+ */
+public class MVCConstructive extends CMSAConstructive<MSTSolution, MSTInstance> {
+
+    /**
+     * Probability of picking the endpoint with the highest remaining degree, instead of the other one.
+     */
+    private final double greedyBias;
+
+    public MVCConstructive() {
+        this(0.8);
+    }
+
+    public MVCConstructive(double greedyBias) {
+        if (greedyBias < 0 || greedyBias > 1) {
+            throw new IllegalArgumentException("greedyBias must be in [0, 1]");
+        }
+        this.greedyBias = greedyBias;
+    }
+
+    @Override
+    public MSTSolution construct(MSTSolution solution) {
+        var instance = solution.getInstance();
+        var rnd = RandomManager.getRandom();
+        var uncovered = new ArrayList<>(instance.getEdges());
+        var selected = new BitSet(instance.v());
+
+        while (!uncovered.isEmpty()) {
+            int idx = rnd.nextInt(uncovered.size());
+            int last = uncovered.size() - 1;
+            Edge edge = uncovered.get(idx);
+            uncovered.set(idx, uncovered.get(last));
+            uncovered.remove(last);
+
+            if (selected.get(edge.from()) || selected.get(edge.to())) {
+                continue; // Already covered by a vertex chosen earlier
+            }
+
+            int chosen = chooseEndpoint(instance, edge, rnd);
+            selected.set(chosen);
+        }
+
+        for (int v = selected.nextSetBit(0); v >= 0; v = selected.nextSetBit(v + 1)) {
+            solution.addToCover(v);
+        }
+        solution.setScoreCover();
+        solution.notifyUpdate();
+        return solution;
+    }
+
+    private int chooseEndpoint(MSTInstance instance, Edge edge, RandomGenerator rnd) {
+        int degFrom = instance.getEdges(edge.from()).size();
+        int degTo = instance.getEdges(edge.to()).size();
+        int higherDegreeEndpoint = degFrom >= degTo ? edge.from() : edge.to();
+        int lowerDegreeEndpoint = degFrom >= degTo ? edge.to() : edge.from();
+        return rnd.nextDouble() < greedyBias ? higherDegreeEndpoint : lowerDegreeEndpoint;
+    }
+
+    @Override
+    public Set<Object> usedComponents(MSTSolution solution) {
+        return new HashSet<>(solution.getCoverVertices());
+    }
+
+    @Override
+    public String toString() {
+        return "MVCConstructive{greedyBias=" + greedyBias + "}";
+    }
+}

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructive.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructive.java
@@ -6,10 +6,10 @@ import es.urjc.etsii.grafo.annotations.RealParam;
 import es.urjc.etsii.grafo.graphs.model.Edge;
 import es.urjc.etsii.grafo.graphs.model.MSTInstance;
 import es.urjc.etsii.grafo.graphs.model.MSTSolution;
+import es.urjc.etsii.grafo.util.CollectionUtil;
 import es.urjc.etsii.grafo.util.random.RandomManager;
 
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Set;
 import java.util.random.RandomGenerator;
 
@@ -45,26 +45,14 @@ public class MVCConstructive extends CMSAConstructive<MSTSolution, MSTInstance, 
     public MSTSolution construct(MSTSolution solution) {
         var instance = solution.getInstance();
         var rnd = RandomManager.getRandom();
-        var uncovered = new ArrayList<>(instance.getEdges());
-        var selected = new BitSet(instance.v());
+        var edges = new ArrayList<>(instance.getEdges());
+        CollectionUtil.shuffle(edges);
 
-        while (!uncovered.isEmpty()) {
-            int idx = rnd.nextInt(uncovered.size());
-            int last = uncovered.size() - 1;
-            Edge edge = uncovered.get(idx);
-            uncovered.set(idx, uncovered.get(last));
-            uncovered.remove(last);
-
-            if (selected.get(edge.from()) || selected.get(edge.to())) {
+        for (Edge edge : edges) {
+            if (solution.isInCover(edge.from()) || solution.isInCover(edge.to())) {
                 continue; // Already covered by a vertex chosen earlier
             }
-
-            int chosen = chooseEndpoint(instance, edge, rnd);
-            selected.set(chosen);
-        }
-
-        for (int v = selected.nextSetBit(0); v >= 0; v = selected.nextSetBit(v + 1)) {
-            solution.addToCover(v);
+            solution.addToCover(chooseEndpoint(instance, edge, rnd));
         }
         solution.setScoreCover();
         solution.notifyUpdate();

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructive.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructive.java
@@ -1,6 +1,8 @@
 package es.urjc.etsii.grafo.graphs.mvc;
 
 import es.urjc.etsii.grafo.algorithms.cmsa.CMSAConstructive;
+import es.urjc.etsii.grafo.annotations.AutoconfigConstructor;
+import es.urjc.etsii.grafo.annotations.RealParam;
 import es.urjc.etsii.grafo.graphs.model.Edge;
 import es.urjc.etsii.grafo.graphs.model.MSTInstance;
 import es.urjc.etsii.grafo.graphs.model.MSTSolution;
@@ -8,7 +10,6 @@ import es.urjc.etsii.grafo.util.random.RandomManager;
 
 import java.util.ArrayList;
 import java.util.BitSet;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.random.RandomGenerator;
 
@@ -21,7 +22,7 @@ import java.util.random.RandomGenerator;
  * cover heuristic), but not always: this randomization is what allows CMSA to sample different,
  * varied vertex subsets across iterations to build the sub-instance.
  */
-public class MVCConstructive extends CMSAConstructive<MSTSolution, MSTInstance> {
+public class MVCConstructive extends CMSAConstructive<MSTSolution, MSTInstance, Integer> {
 
     /**
      * Probability of picking the endpoint with the highest remaining degree, instead of the other one.
@@ -32,7 +33,8 @@ public class MVCConstructive extends CMSAConstructive<MSTSolution, MSTInstance> 
         this(0.8);
     }
 
-    public MVCConstructive(double greedyBias) {
+    @AutoconfigConstructor
+    public MVCConstructive(@RealParam(min = 0, max = 1) double greedyBias) {
         if (greedyBias < 0 || greedyBias > 1) {
             throw new IllegalArgumentException("greedyBias must be in [0, 1]");
         }
@@ -78,8 +80,8 @@ public class MVCConstructive extends CMSAConstructive<MSTSolution, MSTInstance> 
     }
 
     @Override
-    public Set<Object> usedComponents(MSTSolution solution) {
-        return new HashSet<>(solution.getCoverVertices());
+    public Set<Integer> usedComponents(MSTSolution solution) {
+        return solution.getCoverVertices();
     }
 
     @Override

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructive.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructive.java
@@ -18,14 +18,14 @@ import java.util.random.RandomGenerator;
  * "Construct" step of the CMSA demo in this project.
  * <p>
  * Repeatedly picks a random still-uncovered edge, and adds one of its endpoints to the cover,
- * biased towards the endpoint with the highest remaining degree (as in the classic greedy vertex
+ * biased towards the endpoint with the highest degree (as in the classic greedy vertex
  * cover heuristic), but not always: this randomization is what allows CMSA to sample different,
  * varied vertex subsets across iterations to build the sub-instance.
  */
 public class MVCConstructive extends CMSAConstructive<MSTSolution, MSTInstance, Integer> {
 
     /**
-     * Probability of picking the endpoint with the highest remaining degree, instead of the other one.
+     * Probability of picking the endpoint with the highest degree, instead of the other one.
      */
     private final double greedyBias;
 

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolver.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolver.java
@@ -1,12 +1,12 @@
 package es.urjc.etsii.grafo.graphs.mvc;
 
 import es.urjc.etsii.grafo.algorithms.cmsa.CMSASolver;
+import es.urjc.etsii.grafo.annotations.AutoconfigConstructor;
 import es.urjc.etsii.grafo.graphs.model.Edge;
 import es.urjc.etsii.grafo.graphs.model.MSTInstance;
 import es.urjc.etsii.grafo.graphs.model.MSTSolution;
 
 import java.util.BitSet;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -22,30 +22,34 @@ import java.util.Set;
  * dropping the ones that are not selected by this solver. In problems where the sub-instance can
  * grow large, a real MIP/ILP solver would be plugged in instead, implementing the same {@link CMSASolver} contract.
  * <p>
- * Selecting every candidate vertex is always a feasible (if not optimal) solution to the restricted
- * problem, since candidates only ever come from the vertex set of a previously constructed, and
- * therefore already feasible, vertex cover.
+ * When invoked by CMSA, selecting every candidate vertex is a feasible (if not optimal) solution to
+ * the restricted problem because candidates come from previously constructed feasible vertex covers.
+ * The solver validates this invariant and throws an exception if it is violated.
  */
-public class MVCExactCoverSolver extends CMSASolver<MSTSolution, MSTInstance> {
+public class MVCExactCoverSolver extends CMSASolver<MSTSolution, MSTInstance, Integer> {
+
+    @AutoconfigConstructor
+    public MVCExactCoverSolver() {
+    }
 
     @Override
-    public MSTSolution solve(MSTInstance instance, Set<Object> restrictedComponents, long maxDurationInMillis) {
-        var candidates = new HashSet<Integer>();
-        for (var component : restrictedComponents) {
-            candidates.add((Integer) component);
-        }
-
+    public MSTSolution solve(MSTInstance instance, Set<Integer> restrictedComponents, long maxDurationInMillis) {
         List<Edge> edges = instance.getEdges();
         long deadline = System.nanoTime() + maxDurationInMillis * 1_000_000L;
 
-        // Trivial upper bound: selecting every candidate vertex is always feasible
+        // Use every candidate as the initial upper bound, if they form a feasible cover
         BitSet best = new BitSet(instance.v());
-        for (int candidate : candidates) {
+        for (int candidate : restrictedComponents) {
             best.set(candidate);
+        }
+        for (Edge edge : edges) {
+            if (!best.get(edge.from()) && !best.get(edge.to())) {
+                throw new IllegalArgumentException("Restricted components do not form a feasible vertex cover");
+            }
         }
         int[] bestSize = {best.cardinality()};
 
-        search(edges, 0, candidates, new BitSet(instance.v()), best, bestSize, deadline);
+        search(edges, 0, restrictedComponents, new BitSet(instance.v()), best, bestSize, deadline);
 
         MSTSolution solution = new MSTSolution(instance);
         for (int v = best.nextSetBit(0); v >= 0; v = best.nextSetBit(v + 1)) {

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolver.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolver.java
@@ -1,0 +1,105 @@
+package es.urjc.etsii.grafo.graphs.mvc;
+
+import es.urjc.etsii.grafo.algorithms.cmsa.CMSASolver;
+import es.urjc.etsii.grafo.graphs.model.Edge;
+import es.urjc.etsii.grafo.graphs.model.MSTInstance;
+import es.urjc.etsii.grafo.graphs.model.MSTSolution;
+
+import java.util.BitSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Exact solver for the CMSA "Solve" step of the Minimum Vertex Cover demo: given a restricted set
+ * of candidate vertices, finds the smallest subset of those candidates that covers every edge of
+ * the original instance.
+ * <p>
+ * Mork does not bundle any ILP solver, so instead of delegating to CPLEX/Gurobi/OR-Tools, this
+ * implementation performs an exhaustive branch and bound search. This is only tractable because
+ * the restricted sub-instance is expected to stay small: {@link es.urjc.etsii.grafo.algorithms.cmsa.CMSA}
+ * only keeps a limited number of candidate vertices active at any given time, aging out and
+ * dropping the ones that are not selected by this solver. In problems where the sub-instance can
+ * grow large, a real MIP/ILP solver would be plugged in instead, implementing the same {@link CMSASolver} contract.
+ * <p>
+ * Selecting every candidate vertex is always a feasible (if not optimal) solution to the restricted
+ * problem, since candidates only ever come from the vertex set of a previously constructed, and
+ * therefore already feasible, vertex cover.
+ */
+public class MVCExactCoverSolver extends CMSASolver<MSTSolution, MSTInstance> {
+
+    @Override
+    public MSTSolution solve(MSTInstance instance, Set<Object> restrictedComponents, long maxDurationInMillis) {
+        var candidates = new HashSet<Integer>();
+        for (var component : restrictedComponents) {
+            candidates.add((Integer) component);
+        }
+
+        List<Edge> edges = instance.getEdges();
+        long deadline = System.nanoTime() + maxDurationInMillis * 1_000_000L;
+
+        // Trivial upper bound: selecting every candidate vertex is always feasible
+        BitSet best = new BitSet(instance.v());
+        for (int candidate : candidates) {
+            best.set(candidate);
+        }
+        int[] bestSize = {best.cardinality()};
+
+        search(edges, 0, candidates, new BitSet(instance.v()), best, bestSize, deadline);
+
+        MSTSolution solution = new MSTSolution(instance);
+        for (int v = best.nextSetBit(0); v >= 0; v = best.nextSetBit(v + 1)) {
+            solution.addToCover(v);
+        }
+        solution.setScoreCover();
+        solution.notifyUpdate();
+        return solution;
+    }
+
+    /**
+     * Depth-first branch and bound. At each step, covers the first still-uncovered edge (scanning
+     * from {@code scanFrom}, safe because {@code current} only grows on the way down) by trying
+     * both of its candidate endpoints.
+     *
+     * @return true if the search was aborted because the time budget ran out
+     */
+    private boolean search(List<Edge> edges, int scanFrom, Set<Integer> candidates, BitSet current, BitSet best, int[] bestSize, long deadline) {
+        if (System.nanoTime() > deadline) {
+            return true;
+        }
+        if (current.cardinality() >= bestSize[0]) {
+            return false; // Cannot possibly improve on the current best from this branch
+        }
+
+        int firstUncovered = -1;
+        for (int i = scanFrom; i < edges.size(); i++) {
+            Edge edge = edges.get(i);
+            if (!current.get(edge.from()) && !current.get(edge.to())) {
+                firstUncovered = i;
+                break;
+            }
+        }
+
+        if (firstUncovered == -1) {
+            // Every edge is covered: current is feasible and strictly better than best (checked above)
+            best.clear();
+            best.or(current);
+            bestSize[0] = current.cardinality();
+            return false;
+        }
+
+        Edge edge = edges.get(firstUncovered);
+        for (int endpoint : new int[]{edge.from(), edge.to()}) {
+            if (!candidates.contains(endpoint) || current.get(endpoint)) {
+                continue; // Can only select candidate vertices
+            }
+            current.set(endpoint);
+            boolean timeUp = search(edges, firstUncovered + 1, candidates, current, best, bestSize, deadline);
+            current.clear(endpoint);
+            if (timeUp) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolver.java
+++ b/example-graphs/src/main/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolver.java
@@ -37,19 +37,18 @@ public class MVCExactCoverSolver extends CMSASolver<MSTSolution, MSTInstance, In
         List<Edge> edges = instance.getEdges();
         long deadline = System.nanoTime() + maxDurationInMillis * 1_000_000L;
 
-        // Use every candidate as the initial upper bound, if they form a feasible cover
-        BitSet best = new BitSet(instance.v());
+        BitSet candidates = new BitSet(instance.v());
         for (int candidate : restrictedComponents) {
-            best.set(candidate);
+            candidates.set(candidate);
         }
         for (Edge edge : edges) {
-            if (!best.get(edge.from()) && !best.get(edge.to())) {
+            if (!candidates.get(edge.from()) && !candidates.get(edge.to())) {
                 throw new IllegalArgumentException("Restricted components do not form a feasible vertex cover");
             }
         }
-        int[] bestSize = {best.cardinality()};
 
-        search(edges, 0, restrictedComponents, new BitSet(instance.v()), best, bestSize, deadline);
+        BitSet best = (BitSet) candidates.clone();
+        search(edges, 0, candidates, new BitSet(instance.v()), best, deadline);
 
         MSTSolution solution = new MSTSolution(instance);
         for (int v = best.nextSetBit(0); v >= 0; v = best.nextSetBit(v + 1)) {
@@ -67,11 +66,11 @@ public class MVCExactCoverSolver extends CMSASolver<MSTSolution, MSTInstance, In
      *
      * @return true if the search was aborted because the time budget ran out
      */
-    private boolean search(List<Edge> edges, int scanFrom, Set<Integer> candidates, BitSet current, BitSet best, int[] bestSize, long deadline) {
+    private boolean search(List<Edge> edges, int scanFrom, BitSet candidates, BitSet current, BitSet best, long deadline) {
         if (System.nanoTime() > deadline) {
             return true;
         }
-        if (current.cardinality() >= bestSize[0]) {
+        if (current.cardinality() >= best.cardinality()) {
             return false; // Cannot possibly improve on the current best from this branch
         }
 
@@ -88,17 +87,16 @@ public class MVCExactCoverSolver extends CMSASolver<MSTSolution, MSTInstance, In
             // Every edge is covered: current is feasible and strictly better than best (checked above)
             best.clear();
             best.or(current);
-            bestSize[0] = current.cardinality();
             return false;
         }
 
         Edge edge = edges.get(firstUncovered);
         for (int endpoint : new int[]{edge.from(), edge.to()}) {
-            if (!candidates.contains(endpoint) || current.get(endpoint)) {
+            if (!candidates.get(endpoint) || current.get(endpoint)) {
                 continue; // Can only select candidate vertices
             }
             current.set(endpoint);
-            boolean timeUp = search(edges, firstUncovered + 1, candidates, current, best, bestSize, deadline);
+            boolean timeUp = search(edges, firstUncovered + 1, candidates, current, best, deadline);
             current.clear(endpoint);
             if (timeUp) {
                 return true;

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/CMSAMinVertexCoverIntegrationTest.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/CMSAMinVertexCoverIntegrationTest.java
@@ -44,7 +44,7 @@ class CMSAMinVertexCoverIntegrationTest {
     void findsAValidAndReasonablySmallCoverOnARandomGraph() {
         var instance = MSTInstanceImporter.generateErdosRenyi(30, 0.15, 7);
 
-        var cmsa = new CMSABuilder<MSTSolution, MSTInstance>()
+        var cmsa = new CMSABuilder<MSTSolution, MSTInstance, Integer>()
                 .withDefaultObjective()
                 .withConstructive(new MVCConstructive())
                 .withSolver(new MVCExactCoverSolver())
@@ -75,7 +75,7 @@ class CMSAMinVertexCoverIntegrationTest {
         var instance = MSTInstanceImporter.generateErdosRenyi(20, 0.2, 11);
 
         // Run with a single iteration first
-        var single = new CMSABuilder<MSTSolution, MSTInstance>()
+        var single = new CMSABuilder<MSTSolution, MSTInstance, Integer>()
                 .withDefaultObjective()
                 .withConstructive(new MVCConstructive())
                 .withSolver(new MVCExactCoverSolver())
@@ -96,7 +96,7 @@ class CMSAMinVertexCoverIntegrationTest {
 
         // Run again with the same seed, but allow many more iterations
         Context.Configurator.resetRandom(RandomType.DEFAULT, 42);
-        var many = new CMSABuilder<MSTSolution, MSTInstance>()
+        var many = new CMSABuilder<MSTSolution, MSTInstance, Integer>()
                 .withDefaultObjective()
                 .withConstructive(new MVCConstructive())
                 .withSolver(new MVCExactCoverSolver())

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/CMSAMinVertexCoverIntegrationTest.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/CMSAMinVertexCoverIntegrationTest.java
@@ -1,0 +1,121 @@
+package es.urjc.etsii.grafo.graphs.mvc;
+
+import es.urjc.etsii.grafo.algorithms.cmsa.CMSABuilder;
+import es.urjc.etsii.grafo.create.builder.SolutionBuilder;
+import es.urjc.etsii.grafo.graphs.model.MSTInstance;
+import es.urjc.etsii.grafo.graphs.model.MSTInstanceImporter;
+import es.urjc.etsii.grafo.graphs.model.MSTSolution;
+import es.urjc.etsii.grafo.metrics.Metrics;
+import es.urjc.etsii.grafo.solution.Objective;
+import es.urjc.etsii.grafo.util.Context;
+import es.urjc.etsii.grafo.util.random.RandomType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end test: builds a {@code CMSA} algorithm using {@link MVCConstructive} and
+ * {@link MVCExactCoverSolver}, and checks it finds a valid, small vertex cover, without
+ * requiring a full Spring Boot / Mork application context.
+ */
+class CMSAMinVertexCoverIntegrationTest {
+
+    @BeforeAll
+    static void initMetrics() {
+        Metrics.disableMetrics();
+    }
+
+    @BeforeEach
+    void setUp() {
+        Context.reset();
+        Context.Configurator.setObjectives(Objective.ofMinimizing("Score", MSTSolution::getScore, null));
+        Context.Configurator.resetRandom(RandomType.DEFAULT, 42);
+    }
+
+    private void assertIsValidCover(MSTInstance instance, MSTSolution solution) {
+        for (var edge : instance.getEdges()) {
+            Assertions.assertTrue(solution.isInCover(edge.from()) || solution.isInCover(edge.to()),
+                    "Edge " + edge + " is not covered by the solution");
+        }
+    }
+
+    @Test
+    void findsAValidAndReasonablySmallCoverOnARandomGraph() {
+        var instance = MSTInstanceImporter.generateErdosRenyi(30, 0.15, 7);
+
+        var cmsa = new CMSABuilder<MSTSolution, MSTInstance>()
+                .withDefaultObjective()
+                .withConstructive(new MVCConstructive())
+                .withSolver(new MVCExactCoverSolver())
+                .withSolutionsPerIteration(10)
+                .withAgeMax(5)
+                .withSolverTimeLimitInMillis(200)
+                .withMaxIterations(30)
+                .build("CMSA-MVC-Test");
+        cmsa.setBuilder(new SolutionBuilder<>() {
+            @Override
+            public MSTSolution initializeSolution(MSTInstance instance) {
+                return new MSTSolution(instance);
+            }
+        });
+
+        var solution = cmsa.algorithm(instance);
+
+        assertIsValidCover(instance, solution);
+        // A single unbiased random construction is a weak baseline: CMSA must do at least as well.
+        var baseline = new MVCConstructive(0.0).construct(new MSTSolution(instance));
+        Assertions.assertTrue(solution.getCoverSize() <= baseline.getCoverSize(),
+                "CMSA cover (%d) should not be worse than a single unbiased random construction (%d)"
+                        .formatted(solution.getCoverSize(), baseline.getCoverSize()));
+    }
+
+    @Test
+    void adaptsSubInstanceOverIterationsAndKeepsImprovingOrStaying() {
+        var instance = MSTInstanceImporter.generateErdosRenyi(20, 0.2, 11);
+
+        // Run with a single iteration first
+        var single = new CMSABuilder<MSTSolution, MSTInstance>()
+                .withDefaultObjective()
+                .withConstructive(new MVCConstructive())
+                .withSolver(new MVCExactCoverSolver())
+                .withSolutionsPerIteration(5)
+                .withAgeMax(5)
+                .withSolverTimeLimitInMillis(100)
+                .withMaxIterations(1)
+                .build("CMSA-MVC-1iter");
+        single.setBuilder(new SolutionBuilder<>() {
+            @Override
+            public MSTSolution initializeSolution(MSTInstance instance) {
+                return new MSTSolution(instance);
+            }
+        });
+
+        Context.Configurator.resetRandom(RandomType.DEFAULT, 42);
+        var solutionAfter1Iter = single.algorithm(instance);
+
+        // Run again with the same seed, but allow many more iterations
+        Context.Configurator.resetRandom(RandomType.DEFAULT, 42);
+        var many = new CMSABuilder<MSTSolution, MSTInstance>()
+                .withDefaultObjective()
+                .withConstructive(new MVCConstructive())
+                .withSolver(new MVCExactCoverSolver())
+                .withSolutionsPerIteration(5)
+                .withAgeMax(5)
+                .withSolverTimeLimitInMillis(100)
+                .withMaxIterations(30)
+                .build("CMSA-MVC-30iter");
+        many.setBuilder(new SolutionBuilder<>() {
+            @Override
+            public MSTSolution initializeSolution(MSTInstance instance) {
+                return new MSTSolution(instance);
+            }
+        });
+        var solutionAfterManyIters = many.algorithm(instance);
+
+        assertIsValidCover(instance, solutionAfter1Iter);
+        assertIsValidCover(instance, solutionAfterManyIters);
+        Assertions.assertTrue(solutionAfterManyIters.getCoverSize() <= solutionAfter1Iter.getCoverSize(),
+                "Running more CMSA iterations should never yield a worse best solution");
+    }
+}

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/CMSAMinVertexCoverIntegrationTest.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/CMSAMinVertexCoverIntegrationTest.java
@@ -1,5 +1,6 @@
 package es.urjc.etsii.grafo.graphs.mvc;
 
+import es.urjc.etsii.grafo.algorithms.cmsa.CMSA;
 import es.urjc.etsii.grafo.algorithms.cmsa.CMSABuilder;
 import es.urjc.etsii.grafo.create.builder.SolutionBuilder;
 import es.urjc.etsii.grafo.graphs.model.MSTInstance;
@@ -14,12 +15,21 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static es.urjc.etsii.grafo.graphs.mvc.MVCTestFixtures.assertIsValidCover;
+
 /**
  * End-to-end test: builds a {@code CMSA} algorithm using {@link MVCConstructive} and
  * {@link MVCExactCoverSolver}, and checks it finds a valid, small vertex cover, without
  * requiring a full Spring Boot / Mork application context.
  */
 class CMSAMinVertexCoverIntegrationTest {
+
+    private static final SolutionBuilder<MSTSolution, MSTInstance> SOLUTION_BUILDER = new SolutionBuilder<>() {
+        @Override
+        public MSTSolution initializeSolution(MSTInstance instance) {
+            return new MSTSolution(instance);
+        }
+    };
 
     @BeforeAll
     static void initMetrics() {
@@ -33,32 +43,10 @@ class CMSAMinVertexCoverIntegrationTest {
         Context.Configurator.resetRandom(RandomType.DEFAULT, 42);
     }
 
-    private void assertIsValidCover(MSTInstance instance, MSTSolution solution) {
-        for (var edge : instance.getEdges()) {
-            Assertions.assertTrue(solution.isInCover(edge.from()) || solution.isInCover(edge.to()),
-                    "Edge " + edge + " is not covered by the solution");
-        }
-    }
-
     @Test
     void findsAValidAndReasonablySmallCoverOnARandomGraph() {
         var instance = MSTInstanceImporter.generateErdosRenyi(30, 0.15, 7);
-
-        var cmsa = new CMSABuilder<MSTSolution, MSTInstance, Integer>()
-                .withDefaultObjective()
-                .withConstructive(new MVCConstructive())
-                .withSolver(new MVCExactCoverSolver())
-                .withSolutionsPerIteration(10)
-                .withAgeMax(5)
-                .withSolverTimeLimitInMillis(200)
-                .withMaxIterations(30)
-                .build("CMSA-MVC-Test");
-        cmsa.setBuilder(new SolutionBuilder<>() {
-            @Override
-            public MSTSolution initializeSolution(MSTInstance instance) {
-                return new MSTSolution(instance);
-            }
-        });
+        var cmsa = buildCmsa(10, 200, 30);
 
         var solution = cmsa.algorithm(instance);
 
@@ -74,48 +62,35 @@ class CMSAMinVertexCoverIntegrationTest {
     void adaptsSubInstanceOverIterationsAndKeepsImprovingOrStaying() {
         var instance = MSTInstanceImporter.generateErdosRenyi(20, 0.2, 11);
 
-        // Run with a single iteration first
-        var single = new CMSABuilder<MSTSolution, MSTInstance, Integer>()
-                .withDefaultObjective()
-                .withConstructive(new MVCConstructive())
-                .withSolver(new MVCExactCoverSolver())
-                .withSolutionsPerIteration(5)
-                .withAgeMax(5)
-                .withSolverTimeLimitInMillis(100)
-                .withMaxIterations(1)
-                .build("CMSA-MVC-1iter");
-        single.setBuilder(new SolutionBuilder<>() {
-            @Override
-            public MSTSolution initializeSolution(MSTInstance instance) {
-                return new MSTSolution(instance);
-            }
-        });
-
-        Context.Configurator.resetRandom(RandomType.DEFAULT, 42);
+        var single = buildCmsa(5, 100, 1);
         var solutionAfter1Iter = single.algorithm(instance);
 
         // Run again with the same seed, but allow many more iterations
         Context.Configurator.resetRandom(RandomType.DEFAULT, 42);
-        var many = new CMSABuilder<MSTSolution, MSTInstance, Integer>()
-                .withDefaultObjective()
-                .withConstructive(new MVCConstructive())
-                .withSolver(new MVCExactCoverSolver())
-                .withSolutionsPerIteration(5)
-                .withAgeMax(5)
-                .withSolverTimeLimitInMillis(100)
-                .withMaxIterations(30)
-                .build("CMSA-MVC-30iter");
-        many.setBuilder(new SolutionBuilder<>() {
-            @Override
-            public MSTSolution initializeSolution(MSTInstance instance) {
-                return new MSTSolution(instance);
-            }
-        });
+        var many = buildCmsa(5, 100, 30);
         var solutionAfterManyIters = many.algorithm(instance);
 
         assertIsValidCover(instance, solutionAfter1Iter);
         assertIsValidCover(instance, solutionAfterManyIters);
         Assertions.assertTrue(solutionAfterManyIters.getCoverSize() <= solutionAfter1Iter.getCoverSize(),
                 "Running more CMSA iterations should never yield a worse best solution");
+    }
+
+    private CMSA<MSTSolution, MSTInstance, Integer> buildCmsa(
+            int solutionsPerIteration,
+            long solverTimeLimitInMillis,
+            int maxIterations
+    ) {
+        var cmsa = new CMSABuilder<MSTSolution, MSTInstance, Integer>()
+                .withDefaultObjective()
+                .withConstructive(new MVCConstructive())
+                .withSolver(new MVCExactCoverSolver())
+                .withSolutionsPerIteration(solutionsPerIteration)
+                .withAgeMax(5)
+                .withSolverTimeLimitInMillis(solverTimeLimitInMillis)
+                .withMaxIterations(maxIterations)
+                .build("CMSA-MVC-%diter".formatted(maxIterations));
+        cmsa.setBuilder(SOLUTION_BUILDER);
+        return cmsa;
     }
 }

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/CMSAMinVertexCoverIntegrationTest.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/CMSAMinVertexCoverIntegrationTest.java
@@ -51,10 +51,11 @@ class CMSAMinVertexCoverIntegrationTest {
         var solution = cmsa.algorithm(instance);
 
         assertIsValidCover(instance, solution);
-        // A single unbiased random construction is a weak baseline: CMSA must do at least as well.
+        // A single randomized construction with greedyBias=0.0 (always prefers the lower-degree endpoint)
+        // is a weak baseline: CMSA must do at least as well.
         var baseline = new MVCConstructive(0.0).construct(new MSTSolution(instance));
         Assertions.assertTrue(solution.getCoverSize() <= baseline.getCoverSize(),
-                "CMSA cover (%d) should not be worse than a single unbiased random construction (%d)"
+                "CMSA cover (%d) should not be worse than a single randomized construction (%d)"
                         .formatted(solution.getCoverSize(), baseline.getCoverSize()));
     }
 

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructiveTest.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructiveTest.java
@@ -1,7 +1,5 @@
 package es.urjc.etsii.grafo.graphs.mvc;
 
-import es.urjc.etsii.grafo.graphs.model.Edge;
-import es.urjc.etsii.grafo.graphs.model.MSTInstance;
 import es.urjc.etsii.grafo.graphs.model.MSTSolution;
 import es.urjc.etsii.grafo.util.Context;
 import es.urjc.etsii.grafo.util.random.RandomType;
@@ -9,8 +7,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
+import static es.urjc.etsii.grafo.graphs.mvc.MVCTestFixtures.assertIsValidCover;
+import static es.urjc.etsii.grafo.graphs.mvc.MVCTestFixtures.cycleWithPendant;
+import static es.urjc.etsii.grafo.graphs.mvc.MVCTestFixtures.edgeless;
 
 class MVCConstructiveTest {
 
@@ -20,35 +19,9 @@ class MVCConstructiveTest {
         Context.Configurator.resetRandom(RandomType.DEFAULT, 1234);
     }
 
-    /**
-     * Small graph: a 5-cycle (0-1-2-3-4-0) plus a pendant edge (0-5).
-     */
-    private MSTInstance smallInstance() {
-        List<Edge>[] graph = new List[6];
-        for (int i = 0; i < 6; i++) {
-            graph[i] = new ArrayList<>();
-        }
-        List<Edge> edges = new ArrayList<>();
-        int[][] pairs = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 0}, {0, 5}};
-        for (var pair : pairs) {
-            var edge = new Edge(pair[0], pair[1], 1);
-            graph[pair[0]].add(edge);
-            graph[pair[1]].add(edge);
-            edges.add(edge);
-        }
-        return new MSTInstance("small", graph, edges, 1);
-    }
-
-    private void assertIsValidCover(MSTInstance instance, MSTSolution solution) {
-        for (var edge : instance.getEdges()) {
-            Assertions.assertTrue(solution.isInCover(edge.from()) || solution.isInCover(edge.to()),
-                    "Edge " + edge + " is not covered by the solution");
-        }
-    }
-
     @Test
     void constructBuildsAFeasibleCover() {
-        var instance = smallInstance();
+        var instance = cycleWithPendant();
         var constructive = new MVCConstructive();
 
         for (int i = 0; i < 50; i++) {
@@ -60,7 +33,7 @@ class MVCConstructiveTest {
 
     @Test
     void usedComponentsMatchesSelectedVertices() {
-        var instance = smallInstance();
+        var instance = cycleWithPendant();
         var constructive = new MVCConstructive();
         var solution = constructive.construct(new MSTSolution(instance));
 
@@ -70,11 +43,7 @@ class MVCConstructiveTest {
 
     @Test
     void handlesInstanceWithoutEdges() {
-        List<Edge>[] graph = new List[3];
-        for (int i = 0; i < 3; i++) {
-            graph[i] = new ArrayList<>();
-        }
-        var instance = new MSTInstance("no-edges", graph, new ArrayList<>(), 1);
+        var instance = edgeless(3);
         var constructive = new MVCConstructive();
 
         var solution = constructive.construct(new MSTSolution(instance));

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructiveTest.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCConstructiveTest.java
@@ -1,0 +1,83 @@
+package es.urjc.etsii.grafo.graphs.mvc;
+
+import es.urjc.etsii.grafo.graphs.model.Edge;
+import es.urjc.etsii.grafo.graphs.model.MSTInstance;
+import es.urjc.etsii.grafo.graphs.model.MSTSolution;
+import es.urjc.etsii.grafo.util.Context;
+import es.urjc.etsii.grafo.util.random.RandomType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class MVCConstructiveTest {
+
+    @BeforeEach
+    void setUp() {
+        Context.reset();
+        Context.Configurator.resetRandom(RandomType.DEFAULT, 1234);
+    }
+
+    /**
+     * Small graph: a 5-cycle (0-1-2-3-4-0) plus a pendant edge (0-5).
+     */
+    private MSTInstance smallInstance() {
+        List<Edge>[] graph = new List[6];
+        for (int i = 0; i < 6; i++) {
+            graph[i] = new ArrayList<>();
+        }
+        List<Edge> edges = new ArrayList<>();
+        int[][] pairs = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 0}, {0, 5}};
+        for (var pair : pairs) {
+            var edge = new Edge(pair[0], pair[1], 1);
+            graph[pair[0]].add(edge);
+            graph[pair[1]].add(edge);
+            edges.add(edge);
+        }
+        return new MSTInstance("small", graph, edges, 1);
+    }
+
+    private void assertIsValidCover(MSTInstance instance, MSTSolution solution) {
+        for (var edge : instance.getEdges()) {
+            Assertions.assertTrue(solution.isInCover(edge.from()) || solution.isInCover(edge.to()),
+                    "Edge " + edge + " is not covered by the solution");
+        }
+    }
+
+    @Test
+    void constructBuildsAFeasibleCover() {
+        var instance = smallInstance();
+        var constructive = new MVCConstructive();
+
+        for (int i = 0; i < 50; i++) {
+            var solution = constructive.construct(new MSTSolution(instance));
+            assertIsValidCover(instance, solution);
+            Assertions.assertEquals(solution.getCoverSize(), solution.getScore(), 1e-9);
+        }
+    }
+
+    @Test
+    void usedComponentsMatchesSelectedVertices() {
+        var instance = smallInstance();
+        var constructive = new MVCConstructive();
+        var solution = constructive.construct(new MSTSolution(instance));
+
+        var used = constructive.usedComponents(solution);
+        Assertions.assertEquals(solution.getCoverVertices(), used);
+    }
+
+    @Test
+    void handlesInstanceWithoutEdges() {
+        List<Edge>[] graph = new List[3];
+        for (int i = 0; i < 3; i++) {
+            graph[i] = new ArrayList<>();
+        }
+        var instance = new MSTInstance("no-edges", graph, new ArrayList<>(), 1);
+        var constructive = new MVCConstructive();
+
+        var solution = constructive.construct(new MSTSolution(instance));
+        Assertions.assertEquals(0, solution.getCoverSize());
+    }
+}

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolverTest.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolverTest.java
@@ -40,8 +40,8 @@ class MVCExactCoverSolverTest {
         }
     }
 
-    private Set<Object> allVertices(MSTInstance instance) {
-        Set<Object> candidates = new java.util.HashSet<>();
+    private Set<Integer> allVertices(MSTInstance instance) {
+        Set<Integer> candidates = new java.util.HashSet<>();
         for (int v = 0; v < instance.v(); v++) {
             candidates.add(v);
         }
@@ -66,7 +66,7 @@ class MVCExactCoverSolverTest {
 
         // The optimal cover {0,1,3} is already among the candidates: an exact solver
         // restricted to this set must not add any unnecessary vertex.
-        Set<Object> candidates = Set.of(0, 1, 3);
+        Set<Integer> candidates = Set.of(0, 1, 3);
 
         var solution = solver.solve(instance, candidates, 5_000);
 
@@ -82,7 +82,7 @@ class MVCExactCoverSolverTest {
 
         // Excluding vertex 0 forces vertex 5 to be picked to cover edge (0,5),
         // and forces both endpoints of every cycle edge incident to 0 to be picked instead of 0.
-        Set<Object> candidates = Set.of(1, 2, 3, 4, 5);
+        Set<Integer> candidates = Set.of(1, 2, 3, 4, 5);
 
         var solution = solver.solve(instance, candidates, 5_000);
 
@@ -103,5 +103,15 @@ class MVCExactCoverSolverTest {
 
         assertIsValidCover(instance, solution);
         Assertions.assertEquals(instance.v(), solution.getCoverSize());
+    }
+
+    @Test
+    void rejectsCandidatesThatCannotCoverEveryEdge() {
+        var instance = cycleWithPendant();
+        var solver = new MVCExactCoverSolver();
+
+        // Neither endpoint of edge (0, 5) is available.
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> solver.solve(instance, Set.of(1, 2, 3, 4), 5_000));
     }
 }

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolverTest.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolverTest.java
@@ -1,0 +1,107 @@
+package es.urjc.etsii.grafo.graphs.mvc;
+
+import es.urjc.etsii.grafo.graphs.model.Edge;
+import es.urjc.etsii.grafo.graphs.model.MSTInstance;
+import es.urjc.etsii.grafo.graphs.model.MSTSolution;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+class MVCExactCoverSolverTest {
+
+    /**
+     * A 5-cycle (0-1-2-3-4-0) plus a pendant edge (0-5).
+     * Minimum vertex cover size is known to be 3, e.g. {0,1,3}: an odd cycle of length n
+     * needs ceil(n/2) vertices, and vertex 0 also covers the pendant edge for free.
+     */
+    private MSTInstance cycleWithPendant() {
+        List<Edge>[] graph = new List[6];
+        for (int i = 0; i < 6; i++) {
+            graph[i] = new ArrayList<>();
+        }
+        List<Edge> edges = new ArrayList<>();
+        int[][] pairs = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 0}, {0, 5}};
+        for (var pair : pairs) {
+            var edge = new Edge(pair[0], pair[1], 1);
+            graph[pair[0]].add(edge);
+            graph[pair[1]].add(edge);
+            edges.add(edge);
+        }
+        return new MSTInstance("cycle+pendant", graph, edges, 1);
+    }
+
+    private void assertIsValidCover(MSTInstance instance, MSTSolution solution) {
+        for (var edge : instance.getEdges()) {
+            Assertions.assertTrue(solution.isInCover(edge.from()) || solution.isInCover(edge.to()),
+                    "Edge " + edge + " is not covered by the solution");
+        }
+    }
+
+    private Set<Object> allVertices(MSTInstance instance) {
+        Set<Object> candidates = new java.util.HashSet<>();
+        for (int v = 0; v < instance.v(); v++) {
+            candidates.add(v);
+        }
+        return candidates;
+    }
+
+    @Test
+    void solvesToOptimalityWithFullCandidateSet() {
+        var instance = cycleWithPendant();
+        var solver = new MVCExactCoverSolver();
+
+        var solution = solver.solve(instance, allVertices(instance), 5_000);
+
+        assertIsValidCover(instance, solution);
+        Assertions.assertEquals(3, solution.getCoverSize());
+    }
+
+    @Test
+    void neverReturnsMoreVerticesThanCandidatesGiven() {
+        var instance = cycleWithPendant();
+        var solver = new MVCExactCoverSolver();
+
+        // The optimal cover {0,1,3} is already among the candidates: an exact solver
+        // restricted to this set must not add any unnecessary vertex.
+        Set<Object> candidates = Set.of(0, 1, 3);
+
+        var solution = solver.solve(instance, candidates, 5_000);
+
+        assertIsValidCover(instance, solution);
+        Assertions.assertEquals(3, solution.getCoverSize());
+        Assertions.assertEquals(Set.of(0, 1, 3), solution.getCoverVertices());
+    }
+
+    @Test
+    void restrictedCandidatesCanForceASuboptimalButFeasibleCover() {
+        var instance = cycleWithPendant();
+        var solver = new MVCExactCoverSolver();
+
+        // Excluding vertex 0 forces vertex 5 to be picked to cover edge (0,5),
+        // and forces both endpoints of every cycle edge incident to 0 to be picked instead of 0.
+        Set<Object> candidates = Set.of(1, 2, 3, 4, 5);
+
+        var solution = solver.solve(instance, candidates, 5_000);
+
+        assertIsValidCover(instance, solution);
+        Assertions.assertFalse(solution.isInCover(0));
+        Assertions.assertTrue(solution.isInCover(5));
+    }
+
+    @Test
+    void alwaysReturnsAFeasibleSolutionEvenWithNoTimeBudget() {
+        var instance = cycleWithPendant();
+        var solver = new MVCExactCoverSolver();
+        var candidates = allVertices(instance);
+
+        // Search should abort almost immediately, falling back to the trivial
+        // "select every candidate" solution, which must still be feasible.
+        var solution = solver.solve(instance, candidates, 0);
+
+        assertIsValidCover(instance, solution);
+        Assertions.assertEquals(instance.v(), solution.getCoverSize());
+    }
+}

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolverTest.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCExactCoverSolverTest.java
@@ -1,52 +1,15 @@
 package es.urjc.etsii.grafo.graphs.mvc;
 
-import es.urjc.etsii.grafo.graphs.model.Edge;
-import es.urjc.etsii.grafo.graphs.model.MSTInstance;
-import es.urjc.etsii.grafo.graphs.model.MSTSolution;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
+import static es.urjc.etsii.grafo.graphs.mvc.MVCTestFixtures.allVertices;
+import static es.urjc.etsii.grafo.graphs.mvc.MVCTestFixtures.assertIsValidCover;
+import static es.urjc.etsii.grafo.graphs.mvc.MVCTestFixtures.cycleWithPendant;
+
 class MVCExactCoverSolverTest {
-
-    /**
-     * A 5-cycle (0-1-2-3-4-0) plus a pendant edge (0-5).
-     * Minimum vertex cover size is known to be 3, e.g. {0,1,3}: an odd cycle of length n
-     * needs ceil(n/2) vertices, and vertex 0 also covers the pendant edge for free.
-     */
-    private MSTInstance cycleWithPendant() {
-        List<Edge>[] graph = new List[6];
-        for (int i = 0; i < 6; i++) {
-            graph[i] = new ArrayList<>();
-        }
-        List<Edge> edges = new ArrayList<>();
-        int[][] pairs = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 0}, {0, 5}};
-        for (var pair : pairs) {
-            var edge = new Edge(pair[0], pair[1], 1);
-            graph[pair[0]].add(edge);
-            graph[pair[1]].add(edge);
-            edges.add(edge);
-        }
-        return new MSTInstance("cycle+pendant", graph, edges, 1);
-    }
-
-    private void assertIsValidCover(MSTInstance instance, MSTSolution solution) {
-        for (var edge : instance.getEdges()) {
-            Assertions.assertTrue(solution.isInCover(edge.from()) || solution.isInCover(edge.to()),
-                    "Edge " + edge + " is not covered by the solution");
-        }
-    }
-
-    private Set<Integer> allVertices(MSTInstance instance) {
-        Set<Integer> candidates = new java.util.HashSet<>();
-        for (int v = 0; v < instance.v(); v++) {
-            candidates.add(v);
-        }
-        return candidates;
-    }
 
     @Test
     void solvesToOptimalityWithFullCandidateSet() {

--- a/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCTestFixtures.java
+++ b/example-graphs/src/test/java/es/urjc/etsii/grafo/graphs/mvc/MVCTestFixtures.java
@@ -1,0 +1,61 @@
+package es.urjc.etsii.grafo.graphs.mvc;
+
+import es.urjc.etsii.grafo.graphs.model.Edge;
+import es.urjc.etsii.grafo.graphs.model.MSTInstance;
+import es.urjc.etsii.grafo.graphs.model.MSTSolution;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+final class MVCTestFixtures {
+
+    private MVCTestFixtures() {
+    }
+
+    /**
+     * A 5-cycle (0-1-2-3-4-0) plus a pendant edge (0-5).
+     */
+    static MSTInstance cycleWithPendant() {
+        int[][] edges = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 0}, {0, 5}};
+        return graph("cycle+pendant", 6, edges);
+    }
+
+    static MSTInstance edgeless(int vertices) {
+        return graph("no-edges", vertices, new int[][]{});
+    }
+
+    @SuppressWarnings("unchecked")
+    private static MSTInstance graph(String name, int vertices, int[][] endpoints) {
+        List<Edge>[] graph = new List[vertices];
+        for (int i = 0; i < vertices; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        List<Edge> edges = new ArrayList<>();
+        for (int[] endpoint : endpoints) {
+            var edge = new Edge(endpoint[0], endpoint[1], 1);
+            graph[endpoint[0]].add(edge);
+            graph[endpoint[1]].add(edge);
+            edges.add(edge);
+        }
+        return new MSTInstance(name, graph, edges, 1);
+    }
+
+    static void assertIsValidCover(MSTInstance instance, MSTSolution solution) {
+        for (Edge edge : instance.getEdges()) {
+            Assertions.assertTrue(solution.isInCover(edge.from()) || solution.isInCover(edge.to()),
+                    "Edge " + edge + " is not covered by the solution");
+        }
+    }
+
+    static Set<Integer> allVertices(MSTInstance instance) {
+        Set<Integer> candidates = new HashSet<>();
+        for (int vertex = 0; vertex < instance.v(); vertex++) {
+            candidates.add(vertex);
+        }
+        return candidates;
+    }
+}


### PR DESCRIPTION
Introduces a new `algorithms.cmsa` package with the full CMSA flow (`CMSA`, `CMSABuilder`, `CMSAConstructive`, and `CMSASolver`), including parameter validation, iteration/time controls, and adaptation logic over restricted components. Adds unit tests for CMSA behavior and failure cases.

Adds CMSA documentation pages and navigation links, updates the component catalog, and records the feature in the changelog. In `example-graphs`, adds a Minimum Vertex Cover experiment powered by CMSA, a probabilistic MVC constructive, an exact restricted-cover solver, and comprehensive MVC/CMSA tests. `MSTSolution` is extended to support MVC cover state used by the new demo.